### PR TITLE
change activity to oldest message

### DIFF
--- a/components/Pages/Channels/Channel.tsx
+++ b/components/Pages/Channels/Channel.tsx
@@ -171,7 +171,7 @@ export default function Channel({
               </div>
               <div className="text-sm text-gray-400 flex flex-row justify-between">
                 <p>{messages.length} Replies</p>
-                {format(new Date(newestMessage.sentAt))}
+                {format(new Date(oldestMessage.sentAt))}
               </div>
             </div>
           </div>
@@ -226,7 +226,7 @@ export default function Channel({
               {messages.length}
             </td>
             <td className="px-6 py-3 text-sm align-middle min-w-[120px]">
-              {format(new Date(newestMessage.sentAt))}
+              {format(new Date(oldestMessage.sentAt))}
             </td>
           </tr>
         </CustomLink>


### PR DESCRIPTION
It is confusing for users when activity isn't sorted by time
<img width="1005" alt="Screen Shot 2022-05-06 at 7 34 45 PM" src="https://user-images.githubusercontent.com/4218509/167227976-9a434ec0-2865-46ae-9a74-6626c426ff83.png">
 