### PR TITLE
POC :: EC2 cronjob management

### DIFF
--- a/bin/hello/index.ts
+++ b/bin/hello/index.ts
@@ -1,0 +1,5 @@
+export {};
+
+(async () => {
+  console.log('hi, bye', new Date());
+})();

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  apps: [
+    {
+      name: 'hello',
+      script: 'npx ts-node --skip-project bin/hello/index.ts',
+      autorestart: false,
+      cron_restart: '* * * * *',
+    },
+  ],
+};


### PR DESCRIPTION
Hey guys, I create this PR just to share this solution and get feedback from you.
So, the idea is have an easy way to maintain our long running jobs. 
As we discuss it with Jarek today, both agree that we don't need a public API to running those services.
And we shouldn't put too much effort to make a huge queue implementation for this kind of process.
So I believe the fast way is just to create cronjobs on this VM we have and keep it until we need something more.

So, I found this cool app, you probably know already, PM2 (https://pm2.keymetrics.io/docs/usage/process-management/) is like nodemon or forever, just to keep scripts running. 

Well they have this cool feature that is cronjob restarts and autorestart flags that allow us to run some job and when is finish, it don't restart, it will wait for the next cron.

There other cool stuff like the way to check logs or monitor whats happen in the vm: "pm2 monit"

And we can set up all with a file, as the ecosystem.config.js file here in this PR.

The process to update our code I believe will be the same, inside the VM we just pull the new code, we can remove all process pm2 is managing with "pm2 delete all" and start the service with the new config: "pm2 start ecosystem.config.js".

Is there even a way to deploy through ssh, but I didn't had time to try it yet.

Thoughts?