### PR TITLE
Add discord sync to pm2 config file

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,21 @@
+const MINUTES = 60 * 1000;
+
+module.exports = {
+  apps: [
+    {
+      // discord sync process
+      name: 'discord-sync',
+      script: 'npx ts-node --skip-project bin/discord-sync/index.ts',
+      // it will run in a rate of 15 minutes
+      restart_delay: 15 * MINUTES,
+    },
+    {
+      // this process look for empty slugs on database and try to recreate them
+      name: 'slugify',
+      script: 'npx ts-node --skip-project bin/slugify/index.ts',
+      // it will run every night 0:00 gmt-0
+      cron_restart: '0 0 * * *',
+      autorestart: false,
+    },
+  ],
+};


### PR DESCRIPTION
config to help execute long running scripts on ec2

on vm: 

pm2 start ecosystem.config.js
pm2 restart ecosystem.config.js (if config changes)
pm2 delete all (to stop and remove all scripts)
