### PR TITLE
LIN-199 :: threads are duplicate within resolution between 640~760 width

### DIFF
--- a/components/Pages/Channels/Channel.tsx
+++ b/components/Pages/Channels/Channel.tsx
@@ -258,7 +258,7 @@ export default function Channel({
       isSubDomainRouting={isSubDomainRouting}
     >
       <div className="sm:pt-6">
-        <table className="hidden sm:block sm:table-fixed ">
+        <table className="hidden md:block md:table-fixed ">
           <thead>
             <tr>
               <th className="px-6 py-3 text-left font-medium text-gray-500">


### PR DESCRIPTION
- fix styling on channels page

<img width="740" alt="Screen Shot 2022-06-08 at 10 27 48" src="https://user-images.githubusercontent.com/35103955/172628545-2ee1523d-4622-4786-b586-90e6e8787b89.png">
<img width="881" alt="Screen Shot 2022-06-08 at 10 27 59" src="https://user-images.githubusercontent.com/35103955/172628569-b5b6891c-0510-4dac-b0d9-da43f90338b6.png">
