### PR TITLE
Revalidate 404

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,4 +1,4 @@
-export default function NotFound() {
+function NotFoundPage() {
   return (
     <>
       <div className="bg-white min-h-full px-4 py-16 sm:px-6 sm:py-24 md:grid md:place-items-center lg:px-8">
@@ -37,3 +37,12 @@ export default function NotFound() {
     </>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {},
+    revalidate: 5,
+  };
+}
+
+export default NotFoundPage;

--- a/pages/d/[communityName]/t/[threadId]/[slug]/index.tsx
+++ b/pages/d/[communityName]/t/[threadId]/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../../services/threads';
 import Thread from '../../../../../../components/Pages/Thread/Thread';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -14,9 +15,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       revalidate: 60, // In seconds
     };
   } catch (exception) {
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/pages/d/[communityName]/t/[threadId]/index.tsx
+++ b/pages/d/[communityName]/t/[threadId]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../services/threads';
 import Thread from '../../../../../components/Pages/Thread/Thread';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -14,9 +15,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       revalidate: 60, // In seconds
     };
   } catch (exception) {
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/pages/s/[communityName]/t/[threadId]/[slug]/index.tsx
+++ b/pages/s/[communityName]/t/[threadId]/[slug]/index.tsx
@@ -2,6 +2,7 @@ import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../../services/threads';
 import Thread from '../../../../../../components/Pages/Thread/Thread';
 import * as Sentry from '@sentry/nextjs';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -17,9 +18,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   } catch (exception) {
     Sentry.captureException(exception);
 
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/pages/s/[communityName]/t/[threadId]/index.tsx
+++ b/pages/s/[communityName]/t/[threadId]/index.tsx
@@ -2,6 +2,7 @@ import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../services/threads';
 import Thread from '../../../../../components/Pages/Thread/Thread';
 import * as Sentry from '@sentry/nextjs';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -16,9 +17,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     };
   } catch (exception) {
     Sentry.captureException(exception);
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/pages/subdomain/[communityName]/t/[threadId]/[slug]/index.tsx
+++ b/pages/subdomain/[communityName]/t/[threadId]/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../../services/threads';
 import Thread from '../../../../../../components/Pages/Thread/Thread';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -14,9 +15,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       revalidate: 60, // In seconds
     };
   } catch (exception) {
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/pages/subdomain/[communityName]/t/[threadId]/index.tsx
+++ b/pages/subdomain/[communityName]/t/[threadId]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 import { getThreadById } from '../../../../../services/threads';
 import Thread from '../../../../../components/Pages/Thread/Thread';
+import { NotFound } from 'utilities/response';
 
 export default Thread;
 
@@ -14,9 +15,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       revalidate: 60, // In seconds
     };
   } catch (exception) {
-    return {
-      notFound: true,
-    };
+    return NotFound();
   }
 }
 

--- a/services/communities.ts
+++ b/services/communities.ts
@@ -9,6 +9,7 @@ import { links } from '../constants/examples';
 import { GetStaticPropsContext } from 'next/types';
 import { stripProtocol } from '../utilities/url';
 import { accounts, channels, MessagesViewType } from '@prisma/client';
+import { NotFound } from 'utilities/response';
 
 type accountWithChannels = accounts & {
   channels: channels[];
@@ -170,15 +171,15 @@ export const getThreadsByCommunityName = async (
   channelName?: string
 ) => {
   if (!communityName) {
-    return { notFound: true };
+    return null;
   }
 
   const account = await findAccountByPath(communityName);
   if (account === null) {
-    return { notFound: true };
+    return null;
   }
   if (account.channels.length === 0) {
-    return { notFound: true };
+    return null;
   }
 
   const { channel } = identifyChannel({ account, channelName });
@@ -217,8 +218,8 @@ export async function channelGetStaticProps(
     Number(page) || 1,
     channelName
   );
-  if (result.notFound) {
-    return { notFound: true };
+  if (!result) {
+    return NotFound();
   }
   return {
     props: {

--- a/utilities/response.ts
+++ b/utilities/response.ts
@@ -1,0 +1,11 @@
+interface NotFoundResponse {
+  notFound: boolean;
+  revalidate: number;
+}
+
+export function NotFound(): NotFoundResponse {
+  return {
+    notFound: true,
+    revalidate: 5,
+  };
+}


### PR DESCRIPTION
Attempt to fix the sticky 404. It might not be the full answer to the problem, we should not get 404 at ll, but maybe there's a bug in the syncing code. Haven't been able to replicate yet, but the docs are saying that `404` have same `revalidate` behavior so this should make it at least more responsive it happens again.