### PR TITLE
LIN-256/stop-to-prefetch-the-pages-in-the-background

### DIFF
--- a/components/Link/CustomLink.tsx
+++ b/components/Link/CustomLink.tsx
@@ -15,7 +15,7 @@ export default function CustomLink({
     path,
   });
   return (
-    <Link href={href} {...props}>
+    <Link href={href} {...props} prefetch={false}>
       <a>{props.children}</a>
     </Link>
   );

--- a/components/Link/CustomTableRowLink.tsx
+++ b/components/Link/CustomTableRowLink.tsx
@@ -14,5 +14,5 @@ export default function CustomTableRowLink({
     isSubDomainRouting,
     path,
   });
-  return <Link href={href} {...props}></Link>;
+  return <Link href={href} {...props} prefetch={false}></Link>;
 }

--- a/components/Link/index.tsx
+++ b/components/Link/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function Link({ href, children }: Props) {
   return (
-    <NextLink href={href} passHref>
+    <NextLink href={href} passHref prefetch={false}>
       <a className="text-blue-600 hover:text-blue-800 visited:text-purple-600">
         {children}
       </a>


### PR DESCRIPTION
https://nextjs.org/docs/api-reference/next/link

prefetch - Prefetch the page in the background. Defaults to true. Any <Link /> that is in the viewport (initially or through scroll) will be preloaded. Prefetch can be disabled by passing prefetch={false}. 

When prefetch is set to false, prefetching will still occur on hover.