### PR TITLE
LIN-271 :: add support for create & rename channels on slack webhook

### DIFF
--- a/__tests__/pages/api/webhook.channels.test.ts
+++ b/__tests__/pages/api/webhook.channels.test.ts
@@ -1,0 +1,261 @@
+import { accounts, channels } from '@prisma/client';
+import { testApiHandler } from 'next-test-api-route-handler';
+import { prismaMock } from '../../singleton';
+import handler from '../../../pages/api/webhook';
+
+const channelRenameEvent = {
+  token: 'xacv5epJ26YAuNHJeO4UoaNf',
+  team_id: 'T03ECUWHFGD',
+  api_app_id: 'A03DSC9PK4K',
+  event: {
+    type: 'channel_rename',
+    channel: {
+      id: 'C03NGPMCX1C',
+      is_channel: true,
+      is_mpim: false,
+      name: 'newnewch2',
+      name_normalized: 'newnewch2',
+      created: 1657208098,
+    },
+    event_ts: '1657208648.003400',
+  },
+  type: 'event_callback',
+  event_id: 'Ev03N8RA23DM',
+  event_time: 1657208648,
+  authorizations: [
+    {
+      enterprise_id: null,
+      team_id: 'T03ECUWHFGD',
+      user_id: 'U03ENAMC6AE',
+      is_bot: true,
+      is_enterprise_install: false,
+    },
+  ],
+  is_ext_shared_channel: false,
+};
+
+const channelCreatedEvent = {
+  token: 'xacv5epJ26YAuNHJeO4UoaNf',
+  team_id: 'T03ECUWHFGD',
+  api_app_id: 'A03DSC9PK4K',
+  event: {
+    type: 'channel_created',
+    channel: {
+      id: 'C03P28QD4KT',
+      is_channel: true,
+      name: 'new2',
+      name_normalized: 'new2',
+      created: 1657210637,
+      creator: 'U03FCDP4K7S',
+      is_shared: false,
+      is_org_shared: false,
+    },
+    event_ts: '1657210637.005100',
+  },
+  type: 'event_callback',
+  event_id: 'Ev03PDBY3PFA',
+  event_time: 1657210637,
+  authorizations: [
+    {
+      enterprise_id: null,
+      team_id: 'T03ECUWHFGD',
+      user_id: 'U03ENAMC6AE',
+      is_bot: true,
+      is_enterprise_install: false,
+    },
+  ],
+  is_ext_shared_channel: false,
+};
+
+describe('webhook :: channels', () => {
+  describe('channel_created event', () => {
+    test('happy path :: create a new channel', async () => {
+      const accountId = 'accountId';
+      const accountsFindFirstMock =
+        prismaMock.accounts.findFirst.mockResolvedValue({
+          id: accountId,
+        } as accounts);
+      const channelsCreateMock = prismaMock.channels.create.mockResolvedValue(
+        {} as channels
+      );
+
+      await testApiHandler({
+        handler,
+        url: '/api/webhook',
+        test: async ({ fetch }) => {
+          const res = await fetch({
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(channelCreatedEvent),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toStrictEqual({});
+        },
+      });
+
+      expect(accountsFindFirstMock).toHaveBeenCalledWith({
+        select: { id: true },
+        where: { slackTeamId: channelCreatedEvent.team_id },
+      });
+      expect(channelsCreateMock).toHaveBeenCalledWith({
+        data: {
+          channelName: channelCreatedEvent.event.channel.name,
+          accountId,
+          slackChannelId: channelCreatedEvent.event.channel.id,
+          hidden: false,
+        },
+      });
+    });
+
+    test('account does not exists :: it should return 404', async () => {
+      const accountsFindFirstMock =
+        prismaMock.accounts.findFirst.mockResolvedValue(null);
+      await testApiHandler({
+        handler,
+        url: '/api/webhook',
+        test: async ({ fetch }) => {
+          const res = await fetch({
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(channelCreatedEvent),
+          });
+          expect(res.status).toBe(404);
+          await expect(res.json()).resolves.toStrictEqual({
+            error: 'account not found',
+          });
+        },
+      });
+      expect(accountsFindFirstMock).toHaveBeenCalledWith({
+        select: { id: true },
+        where: { slackTeamId: channelCreatedEvent.team_id },
+      });
+    });
+  });
+
+  describe('channel_rename event', () => {
+    test('happy path :: rename channel', async () => {
+      const accountId = 'accountId';
+      const channelId = 'channelId';
+      const accountsFindFirstMock =
+        prismaMock.accounts.findFirst.mockResolvedValue({
+          id: accountId,
+        } as accounts);
+      const channelsFindFirstMock =
+        prismaMock.channels.findFirst.mockResolvedValue({
+          id: channelId,
+        } as channels);
+      const channelsUpdateMock = prismaMock.channels.update.mockResolvedValue(
+        {} as channels
+      );
+      await testApiHandler({
+        handler,
+        url: '/api/webhook',
+        test: async ({ fetch }) => {
+          const res = await fetch({
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(channelRenameEvent),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toStrictEqual({});
+        },
+      });
+      expect(accountsFindFirstMock).toHaveBeenCalledWith({
+        select: { id: true },
+        where: { slackTeamId: channelRenameEvent.team_id },
+      });
+      expect(channelsFindFirstMock).toHaveBeenCalledWith({
+        where: {
+          slackChannelId: channelRenameEvent.event.channel.id,
+          accountId,
+        },
+      });
+      expect(channelsUpdateMock).toHaveBeenCalledWith({
+        where: {
+          id: channelId,
+        },
+        data: {
+          channelName: channelRenameEvent.event.channel.name,
+        },
+      });
+    });
+
+    test('account does not exists :: it should return 404', async () => {
+      const accountsFindFirstMock =
+        prismaMock.accounts.findFirst.mockResolvedValue(null);
+      await testApiHandler({
+        handler,
+        url: '/api/webhook',
+        test: async ({ fetch }) => {
+          const res = await fetch({
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(channelRenameEvent),
+          });
+          expect(res.status).toBe(404);
+          await expect(res.json()).resolves.toStrictEqual({
+            error: 'account not found',
+          });
+        },
+      });
+      expect(accountsFindFirstMock).toHaveBeenCalledWith({
+        select: { id: true },
+        where: { slackTeamId: channelRenameEvent.team_id },
+      });
+    });
+
+    test('channel does not exists :: it should create a new one', async () => {
+      const accountId = 'accountId';
+      const accountsFindFirstMock =
+        prismaMock.accounts.findFirst.mockResolvedValue({
+          id: accountId,
+        } as accounts);
+      const channelsFindFirstMock =
+        prismaMock.channels.findFirst.mockResolvedValue(null);
+      const channelsCreateMock = prismaMock.channels.create.mockResolvedValue(
+        {} as channels
+      );
+      await testApiHandler({
+        handler,
+        url: '/api/webhook',
+        test: async ({ fetch }) => {
+          const res = await fetch({
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(channelRenameEvent),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toStrictEqual({});
+        },
+      });
+      expect(accountsFindFirstMock).toHaveBeenCalledWith({
+        select: { id: true },
+        where: { slackTeamId: channelRenameEvent.team_id },
+      });
+      expect(channelsFindFirstMock).toHaveBeenCalledWith({
+        where: {
+          slackChannelId: channelRenameEvent.event.channel.id,
+          accountId,
+        },
+      });
+      expect(channelsCreateMock).toHaveBeenCalledWith({
+        data: {
+          channelName: channelRenameEvent.event.channel.name,
+          accountId,
+          slackChannelId: channelRenameEvent.event.channel.id,
+          hidden: false,
+        },
+      });
+    });
+  });
+});

--- a/devSetup/sampleAppManifest.yml
+++ b/devSetup/sampleAppManifest.yml
@@ -32,6 +32,10 @@ settings:
       - team_join
       - reaction_added
       - reaction_removed
+    bot_events:
+      - team_join
+      - channel_created
+      - channel_rename
   org_deploy_enabled: false
   socket_mode_enabled: false
   token_rotation_enabled: false

--- a/lib/account.ts
+++ b/lib/account.ts
@@ -22,6 +22,13 @@ export function findAccount({ redirectDomain, logoUrl }: FindAccountParams) {
   });
 }
 
+export function findAccountIdByExternalId(externalId: string) {
+  return prisma.accounts.findFirst({
+    select: { id: true },
+    where: { slackTeamId: externalId },
+  });
+}
+
 export function createAccount({
   homeUrl,
   docsUrl,

--- a/lib/channel.ts
+++ b/lib/channel.ts
@@ -1,0 +1,66 @@
+import prisma from '../client';
+import { stripProtocol } from '../utilities/url';
+
+interface FindChannelParams {
+  name: string;
+  accountId: string;
+}
+
+interface FindChannelByExternalIdParams {
+  externalId: string;
+  accountId: string;
+}
+
+interface CreateChannelParams {
+  name: string;
+  accountId: string;
+  slackChannelId: string;
+  hidden?: boolean;
+}
+
+interface RenameChannelParams {
+  name: string;
+  id: string;
+}
+
+export function findChannel({ name, accountId }: FindChannelParams) {
+  return prisma.channels.findFirst({
+    where: { channelName: name, accountId },
+  });
+}
+
+export function findChannelByExternalId({
+  externalId,
+  accountId,
+}: FindChannelByExternalIdParams) {
+  return prisma.channels.findFirst({
+    where: { slackChannelId: externalId, accountId },
+  });
+}
+
+export function createChannel({
+  name,
+  accountId,
+  slackChannelId,
+  hidden,
+}: CreateChannelParams) {
+  return prisma.channels.create({
+    data: {
+      channelName: name,
+      accountId,
+      slackChannelId,
+      hidden,
+    },
+  });
+}
+
+export function renameChannel({ name, id }: RenameChannelParams) {
+  return prisma.channels.update({
+    where: {
+      id,
+    },
+    data: {
+      channelName: name,
+    },
+  });
+}

--- a/types/slackResponses/slackMessageEventInterface.ts
+++ b/types/slackResponses/slackMessageEventInterface.ts
@@ -8,7 +8,9 @@ export interface SlackEvent {
     | SlackMessageEvent
     | SlackTeamJoinEvent
     | SlackMessageReactionRemovedEvent
-    | SlackMessageReactionAddedEvent;
+    | SlackMessageReactionAddedEvent
+    | SlackChannelCreatedEvent
+    | SlackChannelRenameEvent;
   type: string;
   event_id: string;
   event_time: number;
@@ -89,4 +91,23 @@ export interface Authorization {
   user_id: string;
   is_bot: boolean;
   is_enterprise_install: boolean;
+}
+
+export interface SlackChannelCreatedEvent {
+  type: string;
+  channel: {
+    id: string;
+    name: string;
+    created: number;
+    creator: string;
+  };
+}
+
+export interface SlackChannelRenameEvent {
+  type: string;
+  channel: {
+    id: string;
+    name: string;
+    created: number;
+  };
 }


### PR DESCRIPTION
Need to update our bot manifest on slack, no need for customer reconnection