### PR TITLE
test sentry

### DIFF
--- a/pages/api/sentry.ts
+++ b/pages/api/sentry.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withSentry } from '@sentry/nextjs';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  throw new Error('API throw error test');
+  res.status(200).json({ name: 'John Doe' });
+};
+
+export default withSentry(handler);

--- a/pages/sentry.tsx
+++ b/pages/sentry.tsx
@@ -1,0 +1,14 @@
+export default function Sentry() {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          throw new Error('Sentry Frontend Error');
+        }}
+      >
+        Throw error
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
@cheeseblubber I create this to test sentry integration, still doesn't work.

I wonder if is related to this option set in sentry settings: "Security Token: Outbound requests matching Allowed Domains will have the header '{token_header}: {token}' appended"

Other approach we may take is to implement a nodejs and react sdk integration instead of nextjs sdk, any thoughts?

