### PR TITLE
add race promise to avoid timeout after slack/discord integration

### DIFF
--- a/nextjs/utilities/retryPromises.ts
+++ b/nextjs/utilities/retryPromises.ts
@@ -59,3 +59,11 @@ const jitter = (n: number) => {
   let temp = Math.min(cap, base * 2 ** n);
   return Math.floor(temp / 2 + random_between(0, temp / 2));
 };
+
+export function timeoutAfter(seconds: number) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error('request timed-out'));
+    }, seconds * 1000);
+  });
+}


### PR DESCRIPTION
big communities like kotlinlang or rancher-users had a lot of channels, we try to sync it all after the slack integration but it runs in vercel lambda functions that has 30 seconds of time out. 

I did a race promise to try to sync all channels in less than 5 seconds, if it don't finish in time, it will be sync anyway on the long running process.