### PR TITLE
Adding tests for `/api/auths`

### DIFF
--- a/nextjs/__mocks__/client.ts
+++ b/nextjs/__mocks__/client.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended';
+
+import prisma from '../client';
+
+jest.mock('../client', () => mockDeep<PrismaClient>());
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+
+beforeEach(() => {
+  mockReset(prismaMock);
+});
+
+export default prismaMock;

--- a/nextjs/__tests__/factory/index.ts
+++ b/nextjs/__tests__/factory/index.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export function create(
+  name: string,
+  options?: object
+): NextApiRequest | NextApiResponse {
+  if (name === 'request') {
+    const request = {
+      method: 'GET',
+      body: '{}',
+      ...options,
+    } as NextApiRequest;
+    if (typeof request.body === 'object') {
+      request.body = JSON.stringify(request.body);
+    }
+    return request;
+  }
+  if (name === 'response') {
+    const response = {
+      status: jest.fn().mockReturnThis() as unknown,
+      json: jest.fn() as unknown,
+      ...options,
+    } as NextApiResponse;
+    return response;
+  }
+  throw new Error(`Unknown factory name: ${name}`);
+}

--- a/nextjs/__tests__/pages/api/auth.test.ts
+++ b/nextjs/__tests__/pages/api/auth.test.ts
@@ -1,0 +1,136 @@
+import handler from '../../../pages/api/auth';
+import { create } from '../../factory';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../client';
+import { sendNotification } from '../../../services/slack';
+import ApplicationMailer from '../../../mailers/ApplicationMailer';
+
+jest.mock('../../../client');
+jest.mock('../../../services/slack');
+jest.mock('../../../mailers/ApplicationMailer');
+
+describe('auth', () => {
+  describe('#create', () => {
+    it('creates a new auth', async () => {
+      const request = create('request', {
+        method: 'POST',
+        body: {
+          email: 'john@doe.com',
+          password: '123456',
+        },
+      }) as NextApiRequest;
+      const response = create('response') as NextApiResponse;
+      (prisma.auths.findFirst as jest.Mock).mockResolvedValue(null);
+      await handler(request, response);
+      expect(response.status).toHaveBeenCalledWith(200);
+      expect(response.json).toHaveBeenCalledWith({
+        message: 'Account created, please sign in!',
+      });
+    });
+
+    it('sends a notification', async () => {
+      const request = create('request', {
+        method: 'POST',
+        body: {
+          email: 'john@doe.com',
+          password: '123456',
+        },
+      }) as NextApiRequest;
+      const response = create('response') as NextApiResponse;
+      (prisma.auths.findFirst as jest.Mock).mockResolvedValue(null);
+      await handler(request, response);
+      expect(sendNotification).toHaveBeenCalledWith(
+        'Email created: john@doe.com'
+      );
+    });
+
+    it.skip('sends a verification email', async () => {
+      const request = create('request', {
+        method: 'POST',
+        body: {
+          email: 'john@doe.com',
+          password: '123456',
+        },
+      }) as NextApiRequest;
+      const response = create('response') as NextApiResponse;
+      (prisma.auths.findFirst as jest.Mock).mockResolvedValue(null);
+      await handler(request, response);
+      expect(ApplicationMailer.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'john@doe.com',
+          subject: 'Linen.dev - Verification email',
+        })
+      );
+    });
+
+    describe('when auth already exists', () => {
+      it('returns a 200', async () => {
+        const request = create('request', {
+          method: 'POST',
+          body: {
+            email: 'john@doe.com',
+            password: '123456',
+          },
+        }) as NextApiRequest;
+        const response = create('response') as NextApiResponse;
+        (prisma.auths.findFirst as jest.Mock).mockResolvedValue(null);
+        await handler(request, response);
+        (prisma.auths.findFirst as jest.Mock).mockResolvedValue({});
+        await handler(request, response);
+        expect(response.status).toHaveBeenCalledWith(200);
+        expect(response.json).toHaveBeenCalledWith({
+          message: 'Account exists, please sign in!',
+        });
+      });
+    });
+
+    describe('when email is missing', () => {
+      it('returns an error', async () => {
+        const request = create('request', {
+          method: 'POST',
+        }) as NextApiRequest;
+        const response = create('response') as NextApiResponse;
+        await handler(request, response);
+        expect(response.status).toHaveBeenCalledWith(400);
+        expect(response.json).toHaveBeenCalledWith({
+          error: 'Please provide email',
+        });
+      });
+    });
+
+    describe('when password is missing', () => {
+      it('returns an error', async () => {
+        const request = create('request', {
+          method: 'POST',
+          body: {
+            email: 'john@doe.com',
+          },
+        }) as NextApiRequest;
+        const response = create('response') as NextApiResponse;
+        await handler(request, response);
+        expect(response.status).toHaveBeenCalledWith(400);
+        expect(response.json).toHaveBeenCalledWith({
+          error: 'Please provide password',
+        });
+      });
+    });
+
+    describe('when password has less than 6 characters', () => {
+      it('returns an error', async () => {
+        const request = create('request', {
+          method: 'POST',
+          body: {
+            email: 'john@doe.com',
+            password: '1234',
+          },
+        }) as NextApiRequest;
+        const response = create('response') as NextApiResponse;
+        await handler(request, response);
+        expect(response.status).toHaveBeenCalledWith(400);
+        expect(response.json).toHaveBeenCalledWith({
+          error: 'Password too short',
+        });
+      });
+    });
+  });
+});

--- a/nextjs/jest.setup.js
+++ b/nextjs/jest.setup.js
@@ -1,4 +1,8 @@
 import '@testing-library/jest-dom/extend-expect';
+import { TextEncoder, TextDecoder } from 'util';
 
 window.fetch = jest.fn().mockResolvedValue({});
 global.setImmediate = jest.useRealTimers;
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
This PR is a prerequisite for the email verification story. It adds an example on how to unit test a controller.

I tried to write it in a way that can be easily migrated to express, if we decide to do a migration of the api at some point.

This is strictly a unit test approach, not an integration approach, we should have some of those as well.

<img width="469" alt="Screen Shot 2022-07-30 at 13 49 34" src="https://user-images.githubusercontent.com/2088208/181909648-8fe03965-bff0-4be7-b24f-287cea89c3a9.png">
