### PR TITLE
Allow sending emails from local dev env

### DIFF
--- a/nextjs/mailers/ApplicationMailer.ts
+++ b/nextjs/mailers/ApplicationMailer.ts
@@ -15,7 +15,7 @@ class ApplicationMailer {
   static async send(options: Options) {
     return transporter.sendMail({
       ...options,
-      from: options.from || 'no-reply@linendev.com',
+      from: options.from || transport.auth?.user || 'no-reply@linendev.com',
     });
   }
 }

--- a/nextjs/mailers/transport/index.ts
+++ b/nextjs/mailers/transport/index.ts
@@ -4,11 +4,17 @@ import { sesClient } from '../../services/aws/ses';
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-const sesTransport: SESTransport.Options = {
-  SES: sesClient,
-};
+const testTransport = {
+  host: 'smtp.linen.dev',
+  port: 465,
+  secure: true,
+  auth: { user: 'linen@linen.dev', pass: 'linen' },
+  send(data: any, callback: any) {
+    callback();
+  },
+} as SMTPTransport.Options;
 
-const smtpTransport: SMTPTransport.Options = {
+const smtpTransport = {
   host: process.env.EMAIL_HOST as string,
   port: 465,
   secure: true,
@@ -16,18 +22,28 @@ const smtpTransport: SMTPTransport.Options = {
     user: process.env.EMAIL_USER as string,
     pass: process.env.EMAIL_PASS as string,
   },
+} as SMTPTransport.Options;
+
+const sesTransport = {
+  SES: sesClient,
+} as SESTransport.Options;
+
+interface TransportOptions {
+  SES?: object;
+  host?: string;
+  port?: number;
+  secure?: boolean;
+  auth?: {
+    user: string;
+    pass: string;
+  };
+  send?: (data: any, callback: any) => void;
+}
+
+const transport = {
+  test: testTransport,
+  development: smtpTransport,
+  production: sesTransport,
 };
 
-const transport: Record<string, SESTransport.Options | SMTPTransport.Options> =
-  {
-    // smtp
-    test: smtpTransport,
-    development: smtpTransport,
-    dev: smtpTransport,
-    // ses
-    production: sesTransport,
-  };
-
-export default transport[NODE_ENV] as
-  | SESTransport.Options
-  | SMTPTransport.Options;
+export default transport[NODE_ENV] as TransportOptions;


### PR DESCRIPTION
The main reason for this PR is to allow sending emails locally. Right now it would fail on the newly added `no-reply@linendev.com` if you wanted to use a different email service for testing.

This makes this a bit more service agnostic so you can use any service you like.

I've also added a test transport to ensure that emails are not being sent by accident during tests.