### PR TITLE
LIN-348/title-of-thread-should-be-the-first-message-not-the-last

### DIFF
--- a/nextjs/__tests__/pages/api/webhook.test.ts
+++ b/nextjs/__tests__/pages/api/webhook.test.ts
@@ -237,12 +237,7 @@ describe('webhook', () => {
           where: {
             externalThreadId: addMessageEvent.event.ts,
           },
-          update: {
-            externalThreadId: addMessageEvent.event.ts,
-            channelId: channelMock.id,
-            sentAt: parseSlackSentAt(addMessageEvent.event.ts),
-            slug: createSlug(addMessageEvent.event.text),
-          },
+          update: {},
           create: {
             externalThreadId: addMessageEvent.event.ts,
             channelId: channelMock.id,
@@ -452,12 +447,7 @@ describe('webhook', () => {
           where: {
             externalThreadId: changeMessageEvent.event.message.ts,
           },
-          update: {
-            externalThreadId: changeMessageEvent.event.message.ts,
-            channelId: channelMock.id,
-            sentAt: parseSlackSentAt(changeMessageEvent.event.message.ts),
-            slug: createSlug(changeMessageEvent.event.message.text),
-          },
+          update: {},
           create: {
             externalThreadId: changeMessageEvent.event.message.ts,
             channelId: channelMock.id,

--- a/nextjs/lib/threads.ts
+++ b/nextjs/lib/threads.ts
@@ -26,7 +26,7 @@ export const findOrCreateThread = async (thread: Thread) => {
     where: {
       externalThreadId: thread.externalThreadId,
     },
-    update: thread,
+    update: {},
     create: thread,
     include: {
       messages: true,

--- a/nextjs/services/slack/fetchAllTopLevelMessages.test.ts
+++ b/nextjs/services/slack/fetchAllTopLevelMessages.test.ts
@@ -89,12 +89,7 @@ describe('slackSync :: fetchAllTopLevelMessages', () => {
         sentAt: parseSlackSentAt(conversationHistory.messages[index].ts),
         slug: createSlug(conversationHistory.messages[index].text),
       },
-      update: {
-        channelId: internalChannel.id,
-        externalThreadId: conversationHistory.messages[index].ts,
-        sentAt: parseSlackSentAt(conversationHistory.messages[index].ts),
-        slug: createSlug(conversationHistory.messages[index].text),
-      },
+      update: {},
       where: {
         externalThreadId: conversationHistory.messages[index].ts,
       },

--- a/nextjs/services/slack/saveAllThreads.test.ts
+++ b/nextjs/services/slack/saveAllThreads.test.ts
@@ -130,12 +130,7 @@ describe('slackSync :: saveAllThreads', () => {
       include: {
         messages: true,
       },
-      update: {
-        channelId: internalChannel.id,
-        externalThreadId: threads[0].id,
-        sentAt: parseSlackSentAt(threads[0].externalThreadId),
-        slug: createSlug(conversationReplies.messages[index].text),
-      },
+      update: {},
       where: {
         externalThreadId: threads[0].id,
       },


### PR DESCRIPTION
https://linear.app/linen/issue/LIN-348/title-of-thread-should-be-the-first-message-not-the-last