### PR TITLE
Add a custom emoji to the unsupported set

### DIFF
--- a/nextjs/components/Message/Emoji/utilities/emojis.ts
+++ b/nextjs/components/Message/Emoji/utilities/emojis.ts
@@ -258,4 +258,5 @@ export const UNSUPPORTED_EMOJIS = [
   'hattip',
   'mps-transient',
   'tnx',
+  'sunglasses_lakefs',
 ];


### PR DESCRIPTION
I've explored the possibility to inline/replace react-render-emoji and it's a bit time consuming. It might be worth doing it in the future, trying to find a lighter solution for now.

This fix doesn't include emojis like the text, just reactions.

Other option is to download custom emojis, but that's also time consuming.