### PR TITLE
WIP: schema change

### DIFF
--- a/nextjs/prisma/schema.prisma
+++ b/nextjs/prisma/schema.prisma
@@ -99,7 +99,6 @@ model accounts {
   anonymizeUsers         Boolean          @default(false)
   messagesViewType       MessagesViewType @default(THREADS)
 
-  auths                 auths[]
   users                 users[]
   slackAuthorizations   slackAuthorizations[]
   discordAuthorizations discordAuthorizations[]
@@ -121,8 +120,6 @@ model auths {
   salt      String
   token     String?
 
-  account   accounts? @relation(fields: [accountId], references: [id])
-  accountId String?
   users     users[]
 
   @@unique([email])


### PR DESCRIPTION
Schema change for users and channels.

I plan on reusing the users table and associating with an auth.

We can sync users and the channels they belong to at a later stage.

For admin users we don't have to sync anything since we won't let them send messages for the first version

Don't need to merge this yet just want some feedback on the schema