### PR TITLE
Update the design of the reset password email

### DIFF
--- a/nextjs/mailers/views/components/div.ts
+++ b/nextjs/mailers/views/components/div.ts
@@ -6,11 +6,21 @@ interface Props {
   width?: string;
   height?: string;
   textAlign?: string;
+  style?: string;
 }
 
 export default function div(
-  { align, background, spacing, padding, width, height, textAlign }: Props,
-  children: string
+  {
+    align,
+    background,
+    spacing,
+    padding,
+    width,
+    height,
+    textAlign,
+    style,
+  }: Props,
+  children: string[]
 ): string {
   return `
     <table width="${width || '100%'}" height="${height || 'auto'}" align="${
@@ -20,9 +30,10 @@ export default function div(
   }" border="0" bgcolor="${background || '#ffffff'}">
       <tbody>
         <tr>
-          <td align="${textAlign}">${children}</td>
+          <td style="${style || ''}" align="${textAlign || ''}">${children.map(
+    (child) => child
+  )}</td>
         </tr>
       </tbody>
-    </table>
-  `.trim();
+    </table>`.trim();
 }

--- a/nextjs/mailers/views/components/img.ts
+++ b/nextjs/mailers/views/components/img.ts
@@ -1,0 +1,11 @@
+interface Props {
+  src: string;
+  height?: string;
+  style?: string;
+}
+
+export default function img({ src, height, style }: Props): string {
+  return `
+    <img src="${src}" height="${height || 'auto'}" style="${style || ''}">
+  `.trim();
+}

--- a/nextjs/mailers/views/components/timestamp.ts
+++ b/nextjs/mailers/views/components/timestamp.ts
@@ -1,0 +1,11 @@
+import div from './div';
+
+export default function timestamp() {
+  return div(
+    {
+      background: '#f9fafb',
+      style: 'color: #f9fafb; height: 0;',
+    },
+    ['Timestamp: #' + Date.now()]
+  );
+}

--- a/nextjs/mailers/views/emails/reset-password/index.ts
+++ b/nextjs/mailers/views/emails/reset-password/index.ts
@@ -8,6 +8,7 @@ export default function email({
   token: string;
 }): string {
   return layout(`
-    Reset your password here: <a href='${host}/reset-password?token=${token}'>${host}/reset-password?token=${token}</a>
+    <h1>Forgot your password?</h1>
+    No problem! Reset your password here: <a href='${host}/reset-password?token=${token}'>${host}/reset-password?token=${token}</a>
   `);
 }

--- a/nextjs/mailers/views/layouts/default.ts
+++ b/nextjs/mailers/views/layouts/default.ts
@@ -1,4 +1,6 @@
 import div from '../components/div';
+import img from '../components/img';
+import timestamp from '../components/timestamp';
 
 export default function layout(children: string) {
   return `
@@ -15,15 +17,31 @@ export default function layout(children: string) {
             height: '100%',
             spacing: '48px',
           },
-          div(
-            {
-              background: '#ffffff',
-              padding: '32px',
-              width: '480px',
-              textAlign: 'center',
-            },
-            children.trim()
-          )
+          [
+            img({
+              src: 'https://linen.dev/images/logo/linen.png',
+              height: '36',
+              style: 'margin: 0 auto; display: block;',
+            }),
+            div(
+              {
+                background: '#ffffff',
+                padding: '32px',
+                width: '480px',
+                textAlign: 'center',
+              },
+              [children.trim()]
+            ),
+            div(
+              {
+                background: '#f9fafb',
+                textAlign: 'center',
+                style: 'font-size: 12px; color: #5d7079;',
+              },
+              ['© Rebase Corporation 312 W 20th St New York, NY 10011']
+            ),
+            timestamp(),
+          ]
         )}
       </body>
     </html>


### PR DESCRIPTION
## Overview

The idea behind this PR is to add a default, simple template, that we can use for other emails.

It still needs a little bit of attention (e.g. gmail renders `,` marks in the left, margins could be better, text could be better), but I don't want to get into this too deep yet as it's not the highest priority.

This PR will allow me to do the following things:

1) test out new template in prod without affecting too many users (or any users at all)
2) make the verification PR simpler
3) minimize bug/risk surface, emails are tricky

## Additional notes

The timestamp in the PR is there to inform email clients that the content is unique and we always want to render the whole email. Some email clients decide to shrink messages on their own. We'd like to control it so it doesn't look cut off in the middle (e.g. this is often a problem for signatures).

## Screenshots

<img width="1260" alt="Screen Shot 2022-08-10 at 10 49 26" src="https://user-images.githubusercontent.com/2088208/183858381-710ede24-5ec1-4360-8fa7-b153f9ba8e75.png">
