### PR TITLE
remove option not compatible with SES

### DIFF
--- a/nextjs/mailers/ApplicationMailer.ts
+++ b/nextjs/mailers/ApplicationMailer.ts
@@ -15,7 +15,7 @@ class ApplicationMailer {
   static async send(options: Options) {
     return transporter.sendMail({
       ...options,
-      from: options.from || transport.auth?.user || 'no-reply@linendev.com',
+      from: options.from || 'no-reply@linendev.com',
     });
   }
 }


### PR DESCRIPTION
when set the mailer to work with SES, the auth.user field has the Access Secret Key there. So it is an invalid email format.