### PR TITLE
improves on local development

### DIFF
--- a/nextjs/next.config.js
+++ b/nextjs/next.config.js
@@ -17,6 +17,8 @@ const nextConfig = {
     domains: [
       'avatars.slack-edge.com',
       'cdn.discordapp.com',
+      `linen-assets.s3.amazonaws.com`,
+      'linen-assets.s3.us-east-1.amazonaws.com',
       `${process.env.S3_UPLOAD_BUCKET}.s3.amazonaws.com`,
       `${process.env.S3_UPLOAD_BUCKET}.s3.${process.env.S3_UPLOAD_REGION}.amazonaws.com`,
     ],

--- a/nextjs/utilities/domain.test.ts
+++ b/nextjs/utilities/domain.test.ts
@@ -2,6 +2,6 @@ import { getCurrentUrl } from './domain';
 
 describe('#getCurrentUrl', () => {
   it('returns http://localhost:3000 in local env', () => {
-    expect(getCurrentUrl()).toBe('http://localhost:3000');
+    expect(getCurrentUrl()).toBe(process.env.NEXTAUTH_URL);
   });
 });


### PR DESCRIPTION
for local development, I have this changes in stash all the time because features like sitemap and redirect-domains don't like the port 3000, same for the logos on the frontpage, the logos always use our production s3 links