### PR TITLE
LIN-316 database ssl connection helper

### DIFF
--- a/nextjs/client.ts
+++ b/nextjs/client.ts
@@ -1,6 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { tmpdir } from 'os';
-import fs from 'fs';
+import { getDatabaseUrl } from 'utilities/database';
 
 declare global {
   // allow global `var` declarations
@@ -8,21 +7,17 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-if (!global.prisma && process.env.RDS_CERTIFICATE) {
-  const certOut = `${tmpdir()}/rds-ca-2019-root.pem`;
-  const cert = process.env.RDS_CERTIFICATE;
-  const certExists = fs.existsSync(certOut);
-  if (!certExists) {
-    console.log(`Writing certificate to ${certOut}`);
-    fs.writeFile(certOut, cert, (err) => {
-      if (err) return console.log(err);
-    });
-  }
-}
-
 export const prisma =
   global.prisma ||
   new PrismaClient({
+    datasources: {
+      db: {
+        url: getDatabaseUrl({
+          dbUrl: process.env.DATABASE_URL,
+          cert: process.env.RDS_CERTIFICATE,
+        }),
+      },
+    },
     log: ['warn', 'error'],
   });
 

--- a/nextjs/utilities/database.test.ts
+++ b/nextjs/utilities/database.test.ts
@@ -1,0 +1,44 @@
+jest.mock('os', () => ({
+  tmpdir: jest.fn().mockReturnValue('/temp'),
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  writeFileSync: jest.fn(),
+}));
+
+process.env.RDS_CERTIFICATE = 'RDS_CERTIFICATE';
+import { getDatabaseUrl } from './database';
+
+const cert = 'randomHugeString';
+const certUrl = '/temp/rds-ca-2019-root.pem';
+const dbUrl = 'postgresql://user:pass@domain.com:5432';
+
+describe('database helper', () => {
+  test('it should fail when no dbUrl is set', () => {
+    expect(() =>
+      getDatabaseUrl({
+        cert,
+        dbUrl: undefined,
+      })
+    ).toThrowError('missing dbUrl variable');
+  });
+
+  test('it should append ssl information on the connection string with exist parameters', () => {
+    expect(
+      getDatabaseUrl({
+        cert,
+        dbUrl,
+      })
+    ).toBe(`${dbUrl}?ssl=true&sslrootcert=${certUrl}`);
+  });
+
+  test('it should append ssl information on the connection string without parameters', () => {
+    expect(
+      getDatabaseUrl({
+        cert,
+        dbUrl: dbUrl + '?connect_timeout=300',
+      })
+    ).toBe(`${dbUrl}?connect_timeout=300&ssl=true&sslrootcert=${certUrl}`);
+  });
+});

--- a/nextjs/utilities/database.ts
+++ b/nextjs/utilities/database.ts
@@ -1,0 +1,67 @@
+import os from 'os';
+import fs from 'fs';
+import axios from 'axios';
+
+/**
+ * RDS_CERTIFICATE will be our flag for append ssl data into our db connection string
+ * if is empty, it will skip all ssl related functionalities
+ */
+const isSsl = () => process.env.RDS_CERTIFICATE;
+
+// this url shouldn't change but it could be an environment variable
+const AWS_CERT_URL =
+  'https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem';
+
+const certOut = `${os.tmpdir()}/rds-ca-2019-root.pem`;
+
+function isFileExist() {
+  if (!fs.existsSync(certOut)) throw 'pem not found';
+}
+
+function createFile(data: any) {
+  console.log(`Writing certificate to ${certOut}`);
+  fs.writeFileSync(certOut, String(data));
+  isFileExist();
+}
+
+/**
+ * this function helps fargate tasks to download the cert instead of getting it from env-vars
+ */
+export async function downloadCert() {
+  if (!isSsl()) return;
+  const response = await axios.get(AWS_CERT_URL);
+  createFile(response.data);
+}
+
+/**
+ * this function helps vercel functions to avoid download the cert since it can get it from env-vars
+ */
+function createCertFile({ cert }: { cert?: string }) {
+  if (!isSsl()) return;
+  if (!fs.existsSync(certOut)) {
+    createFile(cert);
+  }
+  return certOut;
+}
+
+/**
+ * this function will return the connection string for our database
+ * - if cert is present, it will persist it as a pem file and append it to our connection string
+ * - if cert is missing, mostly on local development, it will build a connection string without ssl
+ * - if database url is missing, it will throw an exception
+ */
+export function getDatabaseUrl({
+  dbUrl,
+  cert,
+}: {
+  dbUrl?: string;
+  cert?: string;
+}) {
+  if (!dbUrl) throw 'missing dbUrl variable';
+
+  const certLocation = createCertFile({ cert });
+  if (!certLocation) return dbUrl;
+
+  const join = dbUrl.indexOf('?') > -1 ? '&' : '?';
+  return dbUrl + `${join}ssl=true&sslrootcert=${certLocation}`;
+}


### PR DESCRIPTION
build a helper thats will return the connection string for our database

if cert is present, it will persist it as a pem file and append it to our connection string
if cert is missing, mostly on local development, it will build a connection string without ssl
if database url is missing, it will throw an exception
