### PR TITLE
Add secrets

### DIFF
--- a/nextjs/.env.example
+++ b/nextjs/.env.example
@@ -65,6 +65,8 @@ VERCEL_TEAM_ID=
 
 CACHE_TABLE=cache-???
 SKIP_NOTIFICATION=false
+
+NOREPLY_EMAIL=no-reply@linendev.com
 SUPPORT_EMAIL=help@linen.dev
 
 # used to encode the pagination cursor

--- a/nextjs/mailers/ApplicationMailer.ts
+++ b/nextjs/mailers/ApplicationMailer.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import transport from './transport';
+import { NOREPLY_EMAIL } from 'secrets';
 
 const transporter = nodemailer.createTransport(transport);
 
@@ -14,7 +15,7 @@ class ApplicationMailer {
   static async send(options: Options) {
     return transporter.sendMail({
       ...options,
-      from: 'no-reply@linendev.com',
+      from: NOREPLY_EMAIL,
     });
   }
 }

--- a/nextjs/pages/api/auth/[...nextauth].ts
+++ b/nextjs/pages/api/auth/[...nextauth].ts
@@ -1,9 +1,10 @@
 import NextAuth, { type NextAuthOptions } from 'next-auth';
 import EmailProvider from 'next-auth/providers/email';
-import prisma from '../../../client';
+import prisma from 'client';
 import { CustomPrismaAdapter } from 'lib/auth';
 import SignInMailer from 'mailers/SignInMailer';
 import { captureExceptionAndFlush } from 'utilities/sentry';
+import { NOREPLY_EMAIL } from 'secrets';
 
 export const authOptions = {
   pages: {
@@ -22,11 +23,11 @@ export const authOptions = {
           pass: process.env.EMAIL_PASS,
         },
       },
-      from: 'Linen.dev <no-reply@linendev.com>',
+      from: `Linen.dev <${NOREPLY_EMAIL}>`,
 
       async sendVerificationRequest(params) {
         try {
-          const { identifier, url, provider, theme } = params;
+          const { identifier, url } = params;
 
           const result = await SignInMailer.send({
             to: identifier,

--- a/nextjs/secrets.ts
+++ b/nextjs/secrets.ts
@@ -1,0 +1,3 @@
+export const NOREPLY_EMAIL =
+  process.env.NOREPLY_EMAIL || 'no-reply@linendev.com';
+export const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL || 'help@linen.dev';

--- a/nextjs/services/syncStatus.ts
+++ b/nextjs/services/syncStatus.ts
@@ -2,6 +2,7 @@ import ApplicationMailer from '../mailers/ApplicationMailer';
 import { updateAccountSyncStatus } from '../lib/models';
 import { sendNotification } from './slack';
 import { captureExceptionAndFlush } from 'utilities/sentry';
+import { SUPPORT_EMAIL } from 'secrets';
 
 export enum SyncStatus {
   IN_PROGRESS = 'IN_PROGRESS',
@@ -31,7 +32,7 @@ async function emailNotification(
 ) {
   try {
     await ApplicationMailer.send({
-      to: (process.env.SUPPORT_EMAIL || 'help@linen.dev') as string,
+      to: SUPPORT_EMAIL,
       subject: `Linen.dev - Sync progress is ${status} for account: ${accountId}`,
       text: `Syncing process is ${status} for account:  ${accountId}, ${accountName}, ${homeUrl}`,
       html: `Syncing process is ${status} for account:  ${accountId}, ${accountName}, ${homeUrl}`,


### PR DESCRIPTION
## Problem

Handling `env` variables is problematic - some of them are optional, some of them have defaults and need them, some of them don't. Sometimes the format is unknown. Testing code that is based on env variables is problematic in specs.

There are libraries that solve this problem, but I don't think we need one at this point, so instead I've added a `secrets` file (similar approach to ruby on rails).

## Solution

`secrets.ts` file which can have default values. Use secrets rather than accessing variable directly.

In tests, you can mock `secrets` and add a custom implementation you need.
