### PR TITLE
Hide broken thread link

### DIFF
--- a/nextjs/components/Channel/Channel.tsx
+++ b/nextjs/components/Channel/Channel.tsx
@@ -236,7 +236,6 @@ export function Channel({
           <div className="flex justify-center">
             <Thread
               messages={currentThread?.messages || []}
-              threadUrl={''}
               viewCount={currentThread?.viewCount || 0}
               settings={settings}
               isSubDomainRouting={isSubDomainRouting}

--- a/nextjs/components/Thread/Thread.tsx
+++ b/nextjs/components/Thread/Thread.tsx
@@ -16,7 +16,7 @@ export function Thread({
   slug,
 }: {
   messages: SerializedMessage[];
-  threadUrl: string;
+  threadUrl?: string;
   viewCount: number;
   isSubDomainRouting: boolean;
   settings: Settings;
@@ -60,10 +60,12 @@ export function Thread({
       <ul>{elements}</ul>
 
       <div className={styles.footer}>
-        <JoinChannelLink
-          href={threadUrl}
-          communityType={settings.communityType}
-        />
+        {threadUrl && (
+          <JoinChannelLink
+            href={threadUrl}
+            communityType={settings.communityType}
+          />
+        )}
         <div className={styles.count}>
           <span className={styles.subtext}>View count:</span> {viewCount + 1}
         </div>


### PR DESCRIPTION
Right now the `Join thread in Discord` link is broken. Hiding it for now and adding a story for it. 

<img width="444" alt="Screen Shot 2022-09-02 at 13 56 23" src="https://user-images.githubusercontent.com/2088208/188137805-664ae30d-6bbf-4ed9-9808-a74ccbee2c87.png">
