### PR TITLE
Remove revalidate from threads

### DIFF
--- a/nextjs/constants/revalidate.ts
+++ b/nextjs/constants/revalidate.ts
@@ -1,1 +1,0 @@
-export const revalidateInSeconds = 60 * 15;

--- a/nextjs/services/threads.ts
+++ b/nextjs/services/threads.ts
@@ -12,7 +12,6 @@ import {
 import type { users } from '@prisma/client';
 import { GetServerSidePropsContext } from 'next';
 import { NotFound } from '../utilities/response';
-import { revalidateInSeconds } from '../constants/revalidate';
 import { buildSettings } from './accountSettings';
 import { memoize } from '../utilities/dynamoCache';
 import { captureExceptionAndFlush } from 'utilities/sentry';
@@ -120,8 +119,7 @@ export async function threadGetServerSideProps(
   isSubdomainbasedRouting: boolean
 ): Promise<{
   props?: ThreadByIdProp;
-  revalidate?: number;
-  notfound?: boolean;
+  notFound?: boolean;
   redirect?: object;
 }> {
   const access = await PermissionsService.access(context);
@@ -137,12 +135,11 @@ export async function threadGetServerSideProps(
         ...thread,
         isSubDomainRouting: isSubdomainbasedRouting,
       },
-      revalidate: revalidateInSeconds, // In seconds
     };
   } catch (exception) {
     await captureExceptionAndFlush(exception);
     console.error(exception);
-    return { ...NotFound(), revalidate: revalidateInSeconds };
+    return NotFound();
   }
 }
 


### PR DESCRIPTION
Threads have changed from static to server side rendered, so we don't need the revalidate key anymore. Unfortunately `nextjs` throws an error for it rather than trying to take care of it gracefully.