### PR TITLE
allow admins change user roles

### DIFF
--- a/nextjs/pages/api/users.ts
+++ b/nextjs/pages/api/users.ts
@@ -1,0 +1,36 @@
+import { getCurrentUrl } from 'utilities/domain';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Roles } from '@prisma/client';
+import { getAuthFromSession, UserSession } from 'utilities/session';
+import * as userService from 'services/users';
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  const user = await getAuthFromSession(request, response);
+  const host = getCurrentUrl(request);
+
+  if (request.method === 'PUT') {
+    await updateUserRole(user, request.body, host);
+    return response.status(200).json({ message: 'user role updated' });
+  }
+
+  return response.status(405).end();
+}
+
+async function updateUserRole(user: UserSession, body: string, host: string) {
+  const {
+    userId,
+    role,
+  }: {
+    userId: string;
+    role: Roles;
+  } = JSON.parse(body);
+
+  return await userService.updateUserRole({
+    requesterEmail: user.email,
+    userId,
+    role,
+  });
+}

--- a/nextjs/pages/settings/members/index.tsx
+++ b/nextjs/pages/settings/members/index.tsx
@@ -64,12 +64,12 @@ export async function getServerSideProps(
 }
 
 function serializeUsers(
-  users: (auths & {
+  auths: (auths & {
     users: users[];
   })[],
   invites: invites[]
 ): MembersType[] {
-  return users.map(userToMember).concat(invites.map(inviteToMember));
+  return auths.map(userToMember).concat(invites.map(inviteToMember));
 }
 
 function userToMember({
@@ -78,15 +78,18 @@ function userToMember({
 }: auths & {
   users: users[];
 }): MembersType {
+  const user = users.find(Boolean)!;
   return {
+    id: user.id,
     email,
-    role: users?.shift()?.role || 'ADMIN',
+    role: user.role,
     status: 'ACCEPTED',
   };
 }
 
-function inviteToMember({ email, status, role }: invites): MembersType {
+function inviteToMember({ email, status, role, id }: invites): MembersType {
   return {
+    id,
     email,
     role,
     status,

--- a/nextjs/services/users/index.ts
+++ b/nextjs/services/users/index.ts
@@ -1,0 +1,1 @@
+export * from './users';

--- a/nextjs/services/users/users.test.ts
+++ b/nextjs/services/users/users.test.ts
@@ -1,0 +1,156 @@
+import { updateUserRole } from './users';
+import { Roles } from '@prisma/client';
+import prisma from 'client';
+import { v4 } from 'uuid';
+
+describe('user service', () => {
+  describe('update user', () => {
+    test('as admin, update user from same tenant should succeed', async () => {
+      const account = await prisma.accounts.create({ data: {} });
+      const requester = await prisma.auths.create({
+        data: {
+          email: v4(),
+          users: {
+            create: {
+              isAdmin: true,
+              isBot: false,
+              role: Roles.ADMIN,
+              account: { connect: { id: account.id } },
+            },
+          },
+          password: '',
+          salt: '',
+          account: { connect: { id: account.id } },
+        },
+      });
+      const userToUpdate = await prisma.users.create({
+        data: {
+          isAdmin: true,
+          isBot: false,
+          role: Roles.MEMBER,
+          account: { connect: { id: account.id } },
+        },
+      });
+      await expect(
+        updateUserRole({
+          requesterEmail: requester.email,
+          role: Roles.ADMIN,
+          userId: userToUpdate.id,
+        })
+      ).resolves.toMatchObject({
+        accountsId: account.id,
+        anonymousAlias: null,
+        authsId: null,
+        displayName: null,
+        externalUserId: null,
+        id: userToUpdate.id,
+        isAdmin: true,
+        isBot: false,
+        profileImageUrl: null,
+        role: Roles.ADMIN,
+      });
+    });
+
+    test('as admin, update user from distinct tenant should fail', async () => {
+      const account = await prisma.accounts.create({ data: {} });
+      const account2 = await prisma.accounts.create({ data: {} });
+
+      const requester = await prisma.auths.create({
+        data: {
+          email: v4(),
+          users: {
+            create: {
+              isAdmin: true,
+              isBot: false,
+              role: Roles.ADMIN,
+              account: { connect: { id: account.id } },
+            },
+          },
+          password: '',
+          salt: '',
+          account: { connect: { id: account.id } },
+        },
+      });
+      const userToUpdate = await prisma.users.create({
+        data: {
+          isAdmin: true,
+          isBot: false,
+          role: Roles.MEMBER,
+          account: { connect: { id: account2.id } },
+        },
+      });
+
+      await expect(
+        updateUserRole({
+          requesterEmail: requester.email,
+          role: Roles.ADMIN,
+          userId: userToUpdate.id,
+        })
+      ).rejects.toEqual("user doesn't belong to same tenant");
+    });
+
+    test('as owner, update itself to other role without another owner should fail', async () => {
+      const account = await prisma.accounts.create({ data: {} });
+      const requester = await prisma.auths.create({
+        data: {
+          email: v4(),
+          password: '',
+          salt: '',
+          account: { connect: { id: account.id } },
+        },
+      });
+      const userToUpdate = await prisma.users.create({
+        data: {
+          isAdmin: true,
+          isBot: false,
+          role: Roles.OWNER,
+          account: { connect: { id: account.id } },
+          auth: { connect: { id: requester.id } },
+        },
+      });
+
+      await expect(
+        updateUserRole({
+          requesterEmail: requester.email,
+          role: Roles.ADMIN,
+          userId: userToUpdate.id,
+        })
+      ).rejects.toEqual('the account need at least one owner');
+    });
+
+    test('as member, update an user role should fail', async () => {
+      const account = await prisma.accounts.create({ data: {} });
+      const requester = await prisma.auths.create({
+        data: {
+          email: v4(),
+          users: {
+            create: {
+              isAdmin: true,
+              isBot: false,
+              role: Roles.MEMBER,
+              account: { connect: { id: account.id } },
+            },
+          },
+          password: '',
+          salt: '',
+          account: { connect: { id: account.id } },
+        },
+      });
+      const userToUpdate = await prisma.users.create({
+        data: {
+          isAdmin: true,
+          isBot: false,
+          role: Roles.MEMBER,
+          account: { connect: { id: account.id } },
+        },
+      });
+      await expect(
+        updateUserRole({
+          requesterEmail: requester.email,
+          role: Roles.ADMIN,
+          userId: userToUpdate.id,
+        })
+      ).rejects.toEqual('requester is not authorized to make this change');
+    });
+  });
+});

--- a/nextjs/services/users/users.ts
+++ b/nextjs/services/users/users.ts
@@ -1,0 +1,62 @@
+import { Roles } from '@prisma/client';
+import prisma from '../../client';
+
+export async function updateUserRole({
+  requesterEmail: email,
+  userId,
+  role,
+}: {
+  requesterEmail: string;
+  userId: string;
+  role: Roles;
+}) {
+  const auth = await prisma.auths.findFirst({
+    where: {
+      email,
+    },
+    include: { users: true },
+  });
+  if (!auth || !auth.users.length) {
+    throw 'requester not found';
+  }
+  const userToUpdate = await prisma.users.findUnique({
+    where: { id: userId },
+  });
+  if (!userToUpdate) {
+    throw 'user not found';
+  }
+  const userFromSession = auth?.users.find(
+    (u) => u.accountsId === userToUpdate.accountsId
+  );
+  if (!userFromSession) {
+    throw "user doesn't belong to same tenant";
+  }
+  // user requester should be an owner or admin
+  if (
+    userFromSession.role !== Roles.ADMIN &&
+    userFromSession.role !== Roles.OWNER
+  ) {
+    throw 'requester is not authorized to make this change';
+  }
+  // the account it should have at least another owner
+  if (userToUpdate.role === Roles.OWNER && role !== Roles.OWNER) {
+    const anotherOwner = await prisma.users.findFirst({
+      where: {
+        accountsId: userToUpdate.accountsId,
+        role: Roles.OWNER,
+        NOT: {
+          id: userToUpdate.id,
+        },
+      },
+    });
+    if (!anotherOwner) {
+      throw 'the account need at least one owner';
+    }
+  }
+  return await prisma.users.update({
+    where: { id: userToUpdate.id },
+    data: {
+      role,
+    },
+  });
+}

--- a/nextjs/utilities/session.ts
+++ b/nextjs/utilities/session.ts
@@ -1,3 +1,4 @@
+import type { Roles } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { unstable_getServerSession } from 'next-auth';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
@@ -10,10 +11,18 @@ export async function getSession(
   return await unstable_getServerSession(request, response, authOptions);
 }
 
+export type UserSession = {
+  accountId: string;
+  userId: string;
+  role: Roles;
+  authId: string;
+  email: string;
+};
+
 export async function getAuthFromSession(
   request: NextApiRequest,
   response: NextApiResponse
-) {
+): Promise<UserSession> {
   const session = await getSession(request, response);
   if (!session || !session?.user?.email) {
     throw 'missing session';


### PR DESCRIPTION
- as admin, update user from same tenant should succeed
- as admin, update user from distinct tenant should fail
- as owner, update itself to other role without another owner should fail
- as member, update an user role should fail

- as admin, update invite from same tenant should succeed
- as admin, update invite from distinct tenant should fail
- as member, update an invite role should fail