### PR TITLE
Show friendly message for users with member role when accessing settings page

### DIFF
--- a/nextjs/components/Pages/Settings/Settings/ForbiddenCard.tsx
+++ b/nextjs/components/Pages/Settings/Settings/ForbiddenCard.tsx
@@ -1,0 +1,32 @@
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+
+export function ForbiddenCard() {
+  return (
+    <div className="rounded-md bg-yellow-50 p-4 mb-4">
+      <div className="flex">
+        <div className="flex-shrink-0">
+          <FontAwesomeIcon
+            icon={faTriangleExclamation}
+            className="h-5 w-5 text-yellow-400"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="ml-3">
+          <h3 className="text-sm font-medium text-yellow-800">
+            Attention needed
+          </h3>
+          <div className="mt-2 text-sm text-yellow-700">
+            <p>
+              To manage the community you need to be an admin. You current role
+              doesn&apos;t have enough permissions. If you have any questions,
+              please contact your community manager or send us an email at{' '}
+              <a href="mailto:help@linen.dev">help@linen.dev</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nextjs/pages/settings/branding/index.tsx
+++ b/nextjs/pages/settings/branding/index.tsx
@@ -44,7 +44,7 @@ export async function getServerSideProps(context: NextPageContext) {
     return {
       redirect: {
         permanent: false,
-        destination: '../403',
+        destination: '../settings?forbidden=1',
       },
     };
   }

--- a/nextjs/pages/settings/index.tsx
+++ b/nextjs/pages/settings/index.tsx
@@ -1,36 +1,14 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { NextPageContext } from 'next';
 import { getSession } from 'next-auth/react';
-import serializeAccount, { SerializedAccount } from 'serializers/account';
-import { useRouter } from 'next/router';
-import { toast } from 'components/Toast';
+import serializeAccount from 'serializers/account';
 import { channelIndex, findAccountAndUserByEmail } from 'lib/models';
-import Settings from 'components/Pages/Settings';
+import Settings, { SettingsProps } from 'components/Pages/Settings';
 import { sortBy } from 'utilities/sort';
-import { channels, Roles } from '@prisma/client';
+import { Roles } from '@prisma/client';
 
-interface Props {
-  account?: SerializedAccount;
-  channels?: channels[];
-}
-
-export default function SettingsPage({ account, channels }: Props) {
-  const router = useRouter();
-
-  useEffect(() => {
-    const error = router.query.error as string;
-    if (error) {
-      toast.error('Something went wrong, please try again');
-      router.replace(window.location.pathname, undefined, { shallow: true });
-    }
-    const success = router.query.success as string;
-    if (success) {
-      toast.success(decodeURI(success));
-      router.replace(window.location.pathname, undefined, { shallow: true });
-    }
-  }, [router.query, router]);
-
-  return <Settings account={account} channels={channels} />;
+export default function SettingsPage(props: SettingsProps) {
+  return <Settings {...props} />;
 }
 
 export async function getServerSideProps(context: NextPageContext) {
@@ -57,9 +35,10 @@ export async function getServerSideProps(context: NextPageContext) {
 
   if (user && user.role === Roles.MEMBER) {
     return {
-      redirect: {
-        permanent: false,
-        destination: '403',
+      props: {
+        session,
+        account: account && serializeAccount(account),
+        forbidden: true,
       },
     };
   }

--- a/nextjs/pages/settings/members/index.tsx
+++ b/nextjs/pages/settings/members/index.tsx
@@ -47,7 +47,7 @@ export async function getServerSideProps(
     return {
       redirect: {
         permanent: false,
-        destination: '../403',
+        destination: '../settings?forbidden=1',
       },
     };
   }

--- a/nextjs/pages/settings/plans/index.tsx
+++ b/nextjs/pages/settings/plans/index.tsx
@@ -234,7 +234,7 @@ export async function getServerSideProps(context: NextPageContext) {
     return {
       redirect: {
         permanent: false,
-        destination: '../403',
+        destination: '../settings?forbidden=1',
       },
     };
   }


### PR DESCRIPTION
when access settings
<img width="1375" alt="Screen Shot 2022-09-20 at 2 12 32 PM" src="https://user-images.githubusercontent.com/35103955/191324435-4e0e3145-8987-4733-84e0-1d3472803109.png">

when access any subpage from settings (alert with message)
<img width="1375" alt="Screen Shot 2022-09-20 at 2 12 37 PM" src="https://user-images.githubusercontent.com/35103955/191324499-af87ff12-37e4-4957-8d7d-9e19281973ac.png">
