### PR TITLE
feat: add sign with email+password

### DIFF
--- a/nextjs/pages/api/auth.ts
+++ b/nextjs/pages/api/auth.ts
@@ -2,9 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types';
 import prisma from '../../client';
 import { sendNotification } from '../../services/slack';
 import { createAuth } from '../../lib/auth';
-// The unstable_getServerSession only has the prefix unstable_ at the moment, because the API may change in the future. There are no known bugs at the moment and it is safe to use.
-import { unstable_getServerSession as getServerSession } from 'next-auth';
-import { authOptions } from './auth/[...nextauth]';
+import Session from 'services/session';
 import { captureException, withSentry } from '@sentry/nextjs';
 
 async function create(request: NextApiRequest, response: NextApiResponse) {
@@ -46,7 +44,7 @@ async function create(request: NextApiRequest, response: NextApiResponse) {
 }
 
 async function update(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
+  const session = await Session.find(req, res);
   const { createAccount } = JSON.parse(req.body);
 
   const email = session?.user?.email;
@@ -80,7 +78,7 @@ async function update(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function get(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
+  const session = await Session.find(req, res);
   const email = session?.user?.email;
   if (!email) {
     return res.status(404).json({});

--- a/nextjs/pages/api/messages/channel.ts
+++ b/nextjs/pages/api/messages/channel.ts
@@ -1,7 +1,6 @@
 import { findMessagesFromChannel } from 'lib/models';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { withSentry } from '@sentry/nextjs';
 import { prisma } from 'client';
 import serializeThread from 'serializers/thread';
@@ -47,11 +46,7 @@ export async function create(
   request: NextApiRequest,
   response: NextApiResponse<any>
 ) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
   if (!session?.user?.email) {
     throw 'missing session';
   }

--- a/nextjs/pages/api/messages/thread.ts
+++ b/nextjs/pages/api/messages/thread.ts
@@ -1,7 +1,6 @@
 import { findMessagesFromChannel } from 'lib/models';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { withSentry } from '@sentry/nextjs';
 import { prisma } from 'client';
 import serializeMessage from 'serializers/message';
@@ -47,11 +46,7 @@ export async function create(
   request: NextApiRequest,
   response: NextApiResponse<any>
 ) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
   if (!session?.user?.email) {
     throw 'missing session';
   }

--- a/nextjs/pages/api/onboarding/create-channel.ts
+++ b/nextjs/pages/api/onboarding/create-channel.ts
@@ -1,15 +1,10 @@
 import { withSentry } from '@sentry/nextjs';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { OnboardingCreateChannel } from 'services/onboarding';
 
 async function handler(request: NextApiRequest, response: NextApiResponse) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
 
   if (!session?.user?.email) {
     return response.status(401).end();

--- a/nextjs/pages/api/onboarding/create-community.ts
+++ b/nextjs/pages/api/onboarding/create-community.ts
@@ -1,15 +1,10 @@
 import { withSentry } from '@sentry/nextjs';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { OnboardingCreateCommunity } from 'services/onboarding';
 
 async function handler(request: NextApiRequest, response: NextApiResponse) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
   if (!session?.user?.email) {
     return response.status(401).end();
   }

--- a/nextjs/pages/api/onboarding/create-subdomain.ts
+++ b/nextjs/pages/api/onboarding/create-subdomain.ts
@@ -1,15 +1,10 @@
 import { withSentry } from '@sentry/nextjs';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { OnboardingUpdateAccount, PathDomainError } from 'services/onboarding';
 
 async function handler(request: NextApiRequest, response: NextApiResponse) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
 
   if (!session?.user?.email) {
     return response.status(401).end();

--- a/nextjs/pages/api/onboarding/invite-team.ts
+++ b/nextjs/pages/api/onboarding/invite-team.ts
@@ -1,16 +1,11 @@
 import { withSentry } from '@sentry/nextjs';
-import { unstable_getServerSession } from 'next-auth';
+import Session from 'services/session';
 import { NextApiRequest, NextApiResponse } from 'next/types';
-import { authOptions } from '../auth/[...nextauth]';
 import { getCurrentUrl } from 'utilities/domain';
 import { OnboardingInviteTeam } from 'services/onboarding';
 
 async function handler(request: NextApiRequest, response: NextApiResponse) {
-  const session = await unstable_getServerSession(
-    request,
-    response,
-    authOptions
-  );
+  const session = await Session.find(request, response);
 
   if (!session?.user?.email) {
     return response.status(401).end();

--- a/nextjs/pages/api/settings.ts
+++ b/nextjs/pages/api/settings.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { captureException, withSentry } from '@sentry/nextjs';
-import { unstable_getServerSession } from 'next-auth';
-import { authOptions } from './auth/[...nextauth]';
+import Session from 'services/session';
 import { acceptInvite, getOneInviteByUser } from 'services/invites';
 import { Roles } from '@prisma/client';
 import { findAuthByEmail } from 'lib/users';
@@ -11,7 +10,7 @@ import { isRedirectToNewOnboardingEnabled } from 'utilities/featureFlags';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const session = await unstable_getServerSession(req, res, authOptions);
+    const session = await Session.find(req, res);
     if (!session?.user?.email) {
       throw 'missing session';
     }
@@ -41,8 +40,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     return res.redirect('/settings');
   } catch (error) {
+    console.error({ error });
     captureException(error);
-    return res.redirect('https://linen.dev');
+    return res.redirect('/');
   }
 }
 

--- a/nextjs/pages/signin/index.tsx
+++ b/nextjs/pages/signin/index.tsx
@@ -5,7 +5,7 @@ import Link from '../../components/Link';
 import { getCsrfToken } from 'next-auth/react';
 import type { NextPageContext } from 'next';
 import Error from './Error';
-import { useRouter } from 'next/router';
+import PasswordField from 'components/PasswordField';
 import { useState } from 'react';
 
 interface SignInProps {
@@ -13,32 +13,67 @@ interface SignInProps {
   error?: string;
 }
 
+const Anchor = ({ children, onClick }: any) => (
+  <a
+    className="text-blue-600 hover:text-blue-800 cursor-pointer"
+    onClick={onClick}
+  >
+    {children}
+  </a>
+);
+
 export default function SignIn({ csrfToken, error }: SignInProps) {
-  const router = useRouter();
+  const [sign, setSign] = useState<'creds' | 'magic'>('creds');
   const [loading, setLoading] = useState(false);
 
   return (
     <Layout header="Sign In">
       <Error error={error} />
-      <form
-        method="post"
-        action={`/api/auth/signin/email?callbackUrl=${
-          router?.query?.callbackUrl || '/api/settings'
-        }`}
-        onSubmit={() => setLoading(true)}
-      >
-        <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
-        <EmailField label="Email address" id="email" required />
-        <Button type="submit" block disabled={loading}>
-          {loading ? 'Loading...' : 'Sign in with Email'}
-        </Button>
-      </form>
-      <div className="text-sm">
-        <p className="py-3">
-          Don&rsquo;t have an account? <Link href="/signup">Get Started</Link>
-          <br />
-        </p>
-      </div>
+      {sign === 'creds' && (
+        <form
+          method="post"
+          action="/api/auth/callback/credentials?callbackUrl=/api/settings"
+          onSubmit={() => setLoading(true)}
+        >
+          <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+          <EmailField label="Email address" id="email" required />
+          <PasswordField label="Password" id="password" required />
+
+          <p className="py-3 text-sm">
+            <Link href="/forgot-password">Forgot your password?</Link>
+          </p>
+          <Button type="submit" block disabled={loading}>
+            {loading ? 'Loading...' : 'Sign in'}
+          </Button>
+          <div className="flex text-sm justify-between py-3">
+            <Link href="/signup">Don&apos;t have an account?</Link>
+            <Anchor onClick={() => setSign('magic')}>Sign in by email</Anchor>
+          </div>
+        </form>
+      )}
+
+      {sign === 'magic' && (
+        <form
+          method="post"
+          action="/api/auth/signin/email?callbackUrl=/api/settings"
+          onSubmit={() => setLoading(true)}
+        >
+          <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+          <EmailField label="Email address" id="email" required />
+          <Button type="submit" block disabled={loading}>
+            {loading ? 'Loading...' : 'Email me a link'}
+          </Button>
+          <p className="py-3 text-sm">
+            We will send you an email containing a link to sign you in.
+          </p>
+          <div className="flex text-sm justify-between py-3">
+            <Link href="/signup">Don&apos;t have an account?</Link>
+            <Anchor onClick={() => setSign('creds')}>
+              Sign in with credentials
+            </Anchor>
+          </div>
+        </form>
+      )}
     </Layout>
   );
 }

--- a/nextjs/pages/signup/index.tsx
+++ b/nextjs/pages/signup/index.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/router';
 import { getCsrfToken } from 'next-auth/react';
 import type { NextPageContext } from 'next';
 import { useState } from 'react';
+import PasswordField from 'components/PasswordField';
+import Error from 'pages/signin/Error';
 
 interface SignUpProps {
   csrfToken: string;
@@ -14,16 +16,68 @@ interface SignUpProps {
 export default function SignUp({ csrfToken }: SignUpProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const onSubmit = async (event: any) => {
+    event.preventDefault();
+    const form = event.target;
+    const email = form.email.value;
+    const password = form.password.value;
+    if (!email) {
+      setError('Email is required');
+      return;
+    }
+    if (!password) {
+      setError('Password is required');
+      return;
+    }
+    try {
+      setLoading(true);
+      const signUpResponse = await fetch('/api/auth', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      });
+      if (signUpResponse.ok) {
+        const signInResponse = await signIn({ email, password });
+        if (signInResponse.redirected) {
+          window.location.href = signInResponse.url;
+        }
+      } else {
+        throw 'error';
+      }
+    } catch (error) {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  async function signIn({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }) {
+    const csrfToken = await getCsrfToken();
+    return await fetch('/api/auth/callback/credentials?callbackUrl=/settings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        email,
+        password,
+        csrfToken: csrfToken as string,
+      }),
+      redirect: 'follow',
+    });
+  }
 
   return (
     <Layout header="Sign Up for free">
-      <form
-        method="post"
-        action={`/api/auth/signin/email?callbackUrl=${
-          router?.query?.callbackUrl || '/api/settings'
-        }`}
-        onSubmit={() => setLoading(true)}
-      >
+      <Error error={error} />
+      <form onSubmit={onSubmit}>
         <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
         <EmailField
           label="Email address"
@@ -31,10 +85,13 @@ export default function SignUp({ csrfToken }: SignUpProps) {
           required
           defaultValue={router?.query?.email as string}
         />
+        <PasswordField label="Password" id="password" required />
+
         <Button type="submit" block disabled={loading}>
-          {loading ? 'Loading...' : 'Sign up with Email'}
+          {loading ? 'Loading...' : 'Sign up'}
         </Button>
       </form>
+
       <p className="text-sm pt-3 text-gray-600">
         Already have an account? <Link href="/signin">Sign in</Link>
       </p>

--- a/nextjs/services/session/index.ts
+++ b/nextjs/services/session/index.ts
@@ -3,11 +3,12 @@ import {
   NextApiRequest,
   NextApiResponse,
 } from 'next/types';
-import { Session as SessionType } from 'next-auth';
+import type { Session as SessionType } from 'next-auth';
 import { unstable_getServerSession } from 'next-auth/next';
 import { authOptions } from 'pages/api/auth/[...nextauth]';
 import type { users } from '@prisma/client';
 import { findAuthByEmail } from 'lib/users';
+export { type SessionType };
 
 export default class Session {
   static async find(


### PR DESCRIPTION
to enable this feature we had to change to jwt tokens instead of database token.

"It comes with the constraint that users authenticated in this manner are not persisted in the database, and consequently that the Credentials provider can only be used if JSON Web Tokens are enabled for sessions."

https://next-auth.js.org/providers/credentials

<img width="1287" alt="Screen Shot 2022-10-04 at 3 12 38 PM" src="https://user-images.githubusercontent.com/35103955/193894442-6d357758-1577-4384-bdcd-046e59f75548.png">
<img width="1287" alt="Screen Shot 2022-10-04 at 3 12 33 PM" src="https://user-images.githubusercontent.com/35103955/193894451-b739cc27-7d63-4686-86c3-b8996f804532.png">
<img width="1287" alt="Screen Shot 2022-10-04 at 3 12 27 PM" src="https://user-images.githubusercontent.com/35103955/193894459-a5239b4c-b531-4242-a822-bbb21d93c232.png">
<img width="1287" alt="Screen Shot 2022-10-04 at 3 12 19 PM" src="https://user-images.githubusercontent.com/35103955/193894468-3169db2a-5fc1-4879-bcee-dd1c0d35a287.png">
