### PR TITLE
Drop font awesome lib

### DIFF
--- a/nextjs/components/Message/Attachments/Attachment/index.tsx
+++ b/nextjs/components/Message/Attachments/Attachment/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { SerializedAttachment } from 'types/shared';
 import styles from './index.module.css';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFileArrowDown } from '@fortawesome/free-solid-svg-icons';
+import { GoCloudDownload } from 'react-icons/go';
 
 interface Props {
   attachment: SerializedAttachment;
@@ -16,7 +15,7 @@ function Attachment({ attachment }: Props) {
       target="_blank"
       rel="noreferrer"
     >
-      <FontAwesomeIcon className={styles.icon} icon={faFileArrowDown} />
+      <GoCloudDownload className={styles.icon} />
       {attachment.name}
     </a>
   );

--- a/nextjs/components/Pages/Settings/Branding/index.tsx
+++ b/nextjs/components/Pages/Settings/Branding/index.tsx
@@ -10,8 +10,6 @@ import classNames from 'classnames';
 import { useS3Upload } from 'next-s3-upload';
 import { useState } from 'react';
 import { toast } from 'components/Toast';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { SerializedAccount } from 'serializers/account';
 import { useRouter } from 'next/router';
 import { DNSRecord } from 'services/vercel';
@@ -67,6 +65,7 @@ export default function Branding({ account, records }: Props) {
   const router = useRouter();
   let [logoUrl, setLogoUrl] = useState<string>();
   let { FileInput, openFileDialog, uploadToS3, files } = useS3Upload();
+  const isUploading = files && files.length > 0 && files[0].progress < 100;
 
   let handleLogoChange = async (file: File) => {
     let { url } = await uploadToS3(file, {
@@ -188,11 +187,11 @@ export default function Branding({ account, records }: Props) {
             />
           )
         )}
-        <Button onClick={openFileDialog} disabled={!account?.premium}>
-          {files && files.length > 0 && files[0].progress < 100 && (
-            <FontAwesomeIcon icon={faSpinner} spin={true} size="lg" />
-          )}
-          Upload file
+        <Button
+          onClick={() => !isUploading && openFileDialog()}
+          disabled={!account?.premium || isUploading}
+        >
+          {isUploading ? 'Uploading...' : 'Upload file'}
         </Button>
       </PremiumCard>
       <PremiumCard isPremium={account?.premium}>

--- a/nextjs/components/Pages/Settings/Members/index.tsx
+++ b/nextjs/components/Pages/Settings/Members/index.tsx
@@ -8,8 +8,6 @@ import NativeSelect from 'components/NativeSelect';
 import { Roles } from '@prisma/client';
 import { captureException } from '@sentry/nextjs';
 import { toast } from 'components/Toast';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { AiOutlineUser } from 'react-icons/ai';
 
 export interface MembersType {
@@ -161,15 +159,6 @@ function RowMember(user: MembersType, communityId: string): JSX.Element {
         <div className="flex justify-start items-center p-4">
           <p className="grow text-sm font-medium truncate">{user.email}</p>
           <div className="flex pr-4">
-            {loading && (
-              <div className="relative z-10 left-1/2 right-1/2 pt-2">
-                <FontAwesomeIcon
-                  icon={faSpinner}
-                  spin
-                  className="h-5 w-5 text-blue-400 "
-                />
-              </div>
-            )}
             <NativeSelect
               id={user.id}
               value={data.role}

--- a/nextjs/components/Pages/Settings/Settings/ChannelsDefault.tsx
+++ b/nextjs/components/Pages/Settings/Settings/ChannelsDefault.tsx
@@ -1,6 +1,5 @@
 import React, { useState, Fragment } from 'react';
-import { faCheck, faChevronDown } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GoCheck, GoChevronDown } from 'react-icons/go';
 import { Listbox, Transition } from '@headlessui/react';
 import classNames from 'classnames';
 import { SettingsProps, WaitForIntegration } from '..';
@@ -41,10 +40,7 @@ function DropDownChannels({
                 </div>
                 <Listbox.Button className="relative inline-flex items-center bg-blue-700 p-2 rounded-l-none rounded-r-md text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:z-10 focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-50 focus:ring-blue-300">
                   <span className="sr-only">Change default channel</span>
-                  <FontAwesomeIcon
-                    icon={faChevronDown}
-                    className="h-5 w-5 text-white"
-                  />
+                  <GoChevronDown className="h-5 w-5 text-white" />
                 </Listbox.Button>
               </div>
             </div>
@@ -83,10 +79,7 @@ function DropDownChannels({
                                 active ? 'text-white' : 'text-blue-600'
                               }
                             >
-                              <FontAwesomeIcon
-                                icon={faCheck}
-                                className="h-5 w-5"
-                              />
+                              <GoCheck className="h-5 w-5" />
                             </span>
                           ) : null}
                         </div>

--- a/nextjs/components/Pages/Settings/Settings/CommunityIntegration.tsx
+++ b/nextjs/components/Pages/Settings/Settings/CommunityIntegration.tsx
@@ -3,44 +3,28 @@ import { capitalize } from 'utilities/string';
 import { integrationAuthorizer } from 'utilities/communityAuthorizers';
 import { SerializedAccount } from 'serializers/account';
 import { toast } from 'components/Toast';
-import {
-  faSpinner,
-  faCircleCheck,
-  faCircleExclamation,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GoCheck, GoAlert, GoInfo } from 'react-icons/go';
 
 const statusMap: any = {
   NOT_STARTED: (
     <>
-      <FontAwesomeIcon icon={faSpinner} spin className="h-5 w-5 mr-1" /> In
-      progress
+      <GoInfo className="h-5 w-5 mr-1" /> In progress
     </>
   ),
   IN_PROGRESS: (
     <>
-      <FontAwesomeIcon icon={faSpinner} spin className="h-5 w-5 mr-1" /> In
-      progress
+      <GoInfo className="h-5 w-5 mr-1" /> In progress
     </>
   ),
   DONE: (
     <>
-      <FontAwesomeIcon
-        icon={faCircleCheck}
-        color="green"
-        className="h-5 w-5 mr-1"
-      />
+      <GoCheck color="green" className="h-5 w-5 mr-1" />
       Done
     </>
   ),
   ERROR: (
     <>
-      <FontAwesomeIcon
-        icon={faCircleExclamation}
-        className="h-5 w-5 mr-1"
-        color="red"
-      />{' '}
-      Error
+      <GoAlert className="h-5 w-5 mr-1" color="red" /> Error
     </>
   ),
 };

--- a/nextjs/components/Pages/Settings/Settings/ForbiddenCard.tsx
+++ b/nextjs/components/Pages/Settings/Settings/ForbiddenCard.tsx
@@ -1,5 +1,4 @@
-import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GoAlert } from 'react-icons/go';
 import React from 'react';
 
 export function ForbiddenCard() {
@@ -7,11 +6,7 @@ export function ForbiddenCard() {
     <div className="rounded-md bg-yellow-50 p-4 mb-4">
       <div className="flex">
         <div className="flex-shrink-0">
-          <FontAwesomeIcon
-            icon={faTriangleExclamation}
-            className="h-5 w-5 text-yellow-400"
-            aria-hidden="true"
-          />
+          <GoAlert className="h-5 w-5 text-yellow-400" aria-hidden="true" />
         </div>
         <div className="ml-3">
           <h3 className="text-sm font-medium text-yellow-800">

--- a/nextjs/components/Pages/Settings/Settings/ImportFromSlack.tsx
+++ b/nextjs/components/Pages/Settings/Settings/ImportFromSlack.tsx
@@ -98,7 +98,7 @@ export default function ImportFromSlack({
                   className="hidden"
                   accept=".zip"
                 />
-                <Button onClick={openFileDialog}>
+                <Button onClick={openFileDialog} disabled={loading}>
                   {!loading ? 'Upload file' : 'Uploading...'}
                 </Button>
               </div>

--- a/nextjs/components/Pages/Tiers/index.tsx
+++ b/nextjs/components/Pages/Tiers/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Period } from 'pages/settings/plans';
 import { SerializedAccount } from '../../../serializers/account';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { isStripeEnabled } from 'utilities/featureFlags';
+import { GoCheck } from 'react-icons/go';
 
 interface Price {
   id?: string;
@@ -101,10 +100,7 @@ export default function Tiers({ tiers, activePeriod, account }: Props) {
               )
             ) : (
               <a className="shadow-sm mt-8 block w-full bg-green-500 border border-green-500 rounded-md py-2 text-sm font-semibold text-white text-center">
-                <FontAwesomeIcon
-                  icon={faCheck}
-                  className="inline-block h-4 ml-1"
-                />
+                <GoCheck className="inline-block h-4 ml-1" />
               </a>
             )}
           </div>
@@ -115,8 +111,7 @@ export default function Tiers({ tiers, activePeriod, account }: Props) {
             <ul role="list" className="mt-6 space-y-4">
               {tier.features.map((feature) => (
                 <li key={feature} className="flex space-x-3">
-                  <FontAwesomeIcon
-                    icon={faCheck}
+                  <GoCheck
                     className="flex-shrink-0 h-5 w-5 text-green-500"
                     aria-hidden="true"
                   />

--- a/nextjs/components/Toast/index.tsx
+++ b/nextjs/components/Toast/index.tsx
@@ -1,26 +1,12 @@
 import toast from 'react-hot-toast';
 export { Toaster } from 'react-hot-toast';
-import {
-  faCircleCheck,
-  faCircleXmark,
-  faInfoCircle,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GoCheck, GoInfo, GoAlert } from 'react-icons/go';
 
 const customToast = {
   icons: {
-    successIcon: (
-      <FontAwesomeIcon
-        icon={faCircleCheck}
-        className="h-6 w-6 text-green-400"
-      />
-    ),
-    errorIcon: (
-      <FontAwesomeIcon icon={faCircleXmark} className="h-6 w-6 text-red-400" />
-    ),
-    infoIcon: (
-      <FontAwesomeIcon icon={faInfoCircle} className="h-6 w-6 text-blue-400" />
-    ),
+    successIcon: <GoCheck className="h-6 w-6 text-green-400" />,
+    errorIcon: <GoAlert className="h-6 w-6 text-red-400" />,
+    infoIcon: <GoInfo className="h-6 w-6 text-blue-400" />,
   },
 
   success(msg: string, subText?: string) {

--- a/nextjs/components/layout/DashboardLayout/index.tsx
+++ b/nextjs/components/layout/DashboardLayout/index.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import {
-  faGear,
-  faMoneyBill,
-  faPalette,
-  faPlus,
-  faUsers,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SidebarLink from './SidebarLink';
 import { useRouter } from 'next/router';
 import { SerializedAccount } from 'serializers/account';
 import Logo from './Logo';
 import { isNewOnboardingButtonEnabled } from 'utilities/featureFlags';
+import {
+  GoPlus,
+  GoGear,
+  GoSettings,
+  GoOrganization,
+  GoCreditCard,
+} from 'react-icons/go';
 
 interface Props {
   children: React.ReactNode;
@@ -32,9 +31,7 @@ export default function DashboardLayout({ children, header, account }: Props) {
               <div className="space-y-1">
                 <SidebarLink
                   href="/onboarding/create-community"
-                  icon={
-                    <FontAwesomeIcon icon={faPlus} className={iconClassName} />
-                  }
+                  icon={<GoPlus className={iconClassName} />}
                   text="Create new community"
                 />
               </div>
@@ -42,9 +39,7 @@ export default function DashboardLayout({ children, header, account }: Props) {
             <div className="space-y-1">
               <SidebarLink
                 href="/settings"
-                icon={
-                  <FontAwesomeIcon icon={faGear} className={iconClassName} />
-                }
+                icon={<GoGear className={iconClassName} />}
                 text="Settings"
                 active={route === '/settings'}
               />
@@ -52,9 +47,7 @@ export default function DashboardLayout({ children, header, account }: Props) {
             <div className="space-y-1">
               <SidebarLink
                 href="/settings/branding"
-                icon={
-                  <FontAwesomeIcon icon={faPalette} className={iconClassName} />
-                }
+                icon={<GoSettings className={iconClassName} />}
                 text="Branding"
                 active={route === '/settings/branding'}
               />
@@ -62,9 +55,7 @@ export default function DashboardLayout({ children, header, account }: Props) {
             <div className="space-y-1">
               <SidebarLink
                 href="/settings/members"
-                icon={
-                  <FontAwesomeIcon icon={faUsers} className={iconClassName} />
-                }
+                icon={<GoOrganization className={iconClassName} />}
                 text="Members"
                 active={route === '/settings/members'}
               />
@@ -72,12 +63,7 @@ export default function DashboardLayout({ children, header, account }: Props) {
             <div className="space-y-1">
               <SidebarLink
                 href="/settings/plans"
-                icon={
-                  <FontAwesomeIcon
-                    icon={faMoneyBill}
-                    className={iconClassName}
-                  />
-                }
+                icon={<GoCreditCard className={iconClassName} />}
                 text="Plans"
                 active={route === '/settings/plans'}
               />

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -6,10 +6,6 @@
     "": {
       "name": "community",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.1.2",
-        "@fortawesome/free-brands-svg-icons": "^6.1.2",
-        "@fortawesome/free-solid-svg-icons": "^6.1.2",
-        "@fortawesome/react-fontawesome": "^0.2.0",
         "@headlessui/react": "^1.6.6",
         "@prisma/client": "^3.15.2",
         "@sentry/nextjs": "^7.14.1",
@@ -1922,63 +1918,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
-      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
-      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz",
-      "integrity": "sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.2.tgz",
-      "integrity": "sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
       }
     },
     "node_modules/@graphile/logger": {
@@ -17474,43 +17413,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
-      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
-      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      }
-    },
-    "@fortawesome/free-brands-svg-icons": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz",
-      "integrity": "sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.2.tgz",
-      "integrity": "sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.2"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "requires": {
-        "prop-types": "^15.8.1"
       }
     },
     "@graphile/logger": {

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -30,10 +30,6 @@
     "script:import-users": "ts-node -P tsconfig.commonjs.json bin/import-users/index.ts"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.1.2",
-    "@fortawesome/free-brands-svg-icons": "^6.1.2",
-    "@fortawesome/free-solid-svg-icons": "^6.1.2",
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.6.6",
     "@prisma/client": "^3.15.2",
     "@sentry/nextjs": "^7.14.1",

--- a/nextjs/pages/_app.tsx
+++ b/nextjs/pages/_app.tsx
@@ -1,4 +1,3 @@
-import '@fortawesome/fontawesome-svg-core/styles.css';
 import '../styles/reset.css';
 import { useRouter } from 'next/router';
 import '../nprogress.css';

--- a/nextjs/pages/styleguide/examples/Toast.tsx
+++ b/nextjs/pages/styleguide/examples/Toast.tsx
@@ -1,0 +1,21 @@
+import Example from '../Example';
+import Button from 'components/Button';
+import { toast } from 'components/Toast';
+
+export default function TextareaExample() {
+  return (
+    <Example header="Toast">
+      <Example description="Toasts can have different states.">
+        <div>
+          <Button onClick={() => toast.success('Lorem ipsum')}>Success</Button>
+        </div>
+        <div>
+          <Button onClick={() => toast.error('Lorem ipsum')}>Error</Button>
+        </div>
+        <div>
+          <Button onClick={() => toast.info('Lorem ipsum')}>info</Button>
+        </div>
+      </Example>
+    </Example>
+  );
+}

--- a/nextjs/pages/styleguide/index.tsx
+++ b/nextjs/pages/styleguide/index.tsx
@@ -7,6 +7,7 @@ import MessageFormExample from './examples/MessageForm';
 import MessageExample from './examples/Message';
 import TextInputExample from './examples/TextInput';
 import NativeSelectExample from './examples/NativeSelect';
+import ToastExample from './examples/Toast';
 
 export default function Styleguide() {
   return (
@@ -19,6 +20,7 @@ export default function Styleguide() {
       <TextareaExample />
       <NativeSelectExample />
       <AlertExample />
+      <ToastExample />
     </Layout>
   );
 }


### PR DESCRIPTION
Dropping `font-awesome` libs in favor of `react-icons`, which includes some of font awesome icons anyway.

This makes the js/css bundles smaller and simply makes the app faster.

We didn't decide on an icon set yet, so let's continue using `react-icons` for now.