### PR TITLE
fix new button color on settings page

### DIFF
--- a/nextjs/components/Pages/Settings/Settings/LinkCard/index.tsx
+++ b/nextjs/components/Pages/Settings/Settings/LinkCard/index.tsx
@@ -24,7 +24,7 @@ export default function LinkCard({ account }: Props) {
           </div>
         </div>
       </div>
-      <div className="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+      <div className="inline-flex items-center rounded-md border border-transparent bg-blue-700 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
         <a href={url} target="_blank" rel="noreferrer">
           {text}
         </a>


### PR DESCRIPTION
new: 
<img width="944" alt="Screen Shot 2022-10-19 at 1 07 56 PM" src="https://user-images.githubusercontent.com/35103955/196745582-dead72a3-91b2-46be-89c3-8d07432c07ff.png">


old (purple):
<img width="944" alt="Screen Shot 2022-10-19 at 1 08 30 PM" src="https://user-images.githubusercontent.com/35103955/196745700-76a5469d-7bcb-4044-9ff1-035d5b279e93.png">
