### PR TITLE
Support shift key in the feed

### DIFF
--- a/nextjs/components/Pages/Feed/Content/index.tsx
+++ b/nextjs/components/Pages/Feed/Content/index.tsx
@@ -22,6 +22,7 @@ import useFeedWebsockets from 'hooks/websockets/feed';
 import type { CommunityPushType } from 'services/push';
 import { toast } from 'components/Toast';
 import { SerializedMessage } from 'serializers/message';
+import { manageSelections } from '../utilities/selection';
 
 interface Props {
   communityId: string;
@@ -168,7 +169,7 @@ export default function Feed({
     const ids: string[] = [];
     for (const key in selections) {
       const selection = selections[key];
-      if (selection) {
+      if (selection?.checked) {
         ids.push(key);
       }
     }
@@ -351,10 +352,14 @@ export default function Feed({
               selections={selections}
               onChange={(id: string, checked: boolean, index: number) => {
                 setSelections((selections: Selections) => {
-                  return {
-                    ...selections,
-                    [id]: checked,
-                  };
+                  return manageSelections({
+                    id,
+                    checked,
+                    index,
+                    selections,
+                    ids: feed.threads.map((thread) => thread.id),
+                    isShiftPressed,
+                  });
                 });
               }}
               onSelect={(thread: SerializedThread) => {

--- a/nextjs/components/Pages/Feed/Content/index.tsx
+++ b/nextjs/components/Pages/Feed/Content/index.tsx
@@ -15,6 +15,7 @@ import debounce from 'utilities/debounce';
 import { sendMessageWrapper } from './sendMessageWrapper';
 import usePolling from 'hooks/polling';
 import useThreadWebsockets from 'hooks/websockets/thread';
+import useKeyboard from 'hooks/keyboard';
 import { useUsersContext } from 'contexts/Users';
 import { useJoinContext } from 'contexts/Join';
 import useFeedWebsockets from 'hooks/websockets/feed';
@@ -67,6 +68,7 @@ export default function Feed({
   const ref = useRef<HTMLDivElement>(null);
   const [allUsers] = useUsersContext();
   const { startSignUp } = useJoinContext();
+  const { isShiftPressed } = useKeyboard();
 
   useThreadWebsockets({
     id: thread?.id,
@@ -347,7 +349,7 @@ export default function Feed({
               threads={feed.threads}
               loading={polling}
               selections={selections}
-              onChange={(id: string, checked: boolean) => {
+              onChange={(id: string, checked: boolean, index: number) => {
                 setSelections((selections: Selections) => {
                   return {
                     ...selections,

--- a/nextjs/components/Pages/Feed/Filters/index.tsx
+++ b/nextjs/components/Pages/Feed/Filters/index.tsx
@@ -25,7 +25,7 @@ interface Props {
 function showActions(selections: Selections): boolean {
   for (const key in selections) {
     const selection = selections[key];
-    if (selection) {
+    if (selection?.checked) {
       return true;
     }
   }

--- a/nextjs/components/Pages/Feed/Grid/index.tsx
+++ b/nextjs/components/Pages/Feed/Grid/index.tsx
@@ -28,7 +28,7 @@ export default function Grid({
           <Row
             key={thread.id + index}
             thread={thread}
-            selected={!!selections[thread.id]}
+            selected={!!selections[thread.id]?.checked}
             onChange={(id, checked) => onChange(id, checked, index)}
             onClick={() => onSelect(thread)}
           />

--- a/nextjs/components/Pages/Feed/Grid/index.tsx
+++ b/nextjs/components/Pages/Feed/Grid/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   threads: SerializedThread[];
   selections: Selections;
   loading: boolean;
-  onChange(id: string, checked: boolean): void;
+  onChange(id: string, checked: boolean, index: number): void;
   onSelect(thread: SerializedThread): void;
 }
 
@@ -29,7 +29,7 @@ export default function Grid({
             key={thread.id + index}
             thread={thread}
             selected={!!selections[thread.id]}
-            onChange={onChange}
+            onChange={(id, checked) => onChange(id, checked, index)}
             onClick={() => onSelect(thread)}
           />
         );

--- a/nextjs/components/Pages/Feed/types.ts
+++ b/nextjs/components/Pages/Feed/types.ts
@@ -6,5 +6,8 @@ export interface FeedResponse {
 }
 
 export interface Selections {
-  [key: string]: boolean;
+  [key: string]: {
+    checked: boolean;
+    index: number;
+  };
 }

--- a/nextjs/components/Pages/Feed/utilities/selection.spec.ts
+++ b/nextjs/components/Pages/Feed/utilities/selection.spec.ts
@@ -1,0 +1,57 @@
+import { manageSelections } from './selection';
+
+describe('manageSelections', () => {
+  describe('when there are no selections', () => {
+    describe('and an item is selected', () => {
+      it('adds it to selections', () => {
+        const id = '1';
+        const selections = manageSelections({
+          id,
+          checked: true,
+          index: 0,
+          selections: {},
+          ids: ['1'],
+          isShiftPressed: false,
+        });
+        expect(Object.keys(selections).length).toEqual(1);
+        expect(selections[id]).toEqual({ checked: true, index: 0 });
+      });
+    });
+
+    describe('and shift key is pressed', () => {
+      describe('and an item is selected', () => {
+        it('adds multiple selections', () => {
+          const id = '4';
+          const selections = manageSelections({
+            id,
+            checked: true,
+            index: 3,
+            selections: {},
+            ids: ['1', '2', '3', '4'],
+            isShiftPressed: true,
+          });
+          expect(Object.keys(selections).length).toEqual(4);
+        });
+      });
+    });
+  });
+
+  describe('when there is one selection', () => {
+    describe('and an item is deselected', () => {
+      it('removes it from selections', () => {
+        const id = '1';
+        const selections = manageSelections({
+          id,
+          checked: false,
+          index: 0,
+          selections: {
+            [id]: { checked: true, index: 0 },
+          },
+          ids: ['1'],
+          isShiftPressed: false,
+        });
+        expect(Object.keys(selections).length).toEqual(0);
+      });
+    });
+  });
+});

--- a/nextjs/components/Pages/Feed/utilities/selection.ts
+++ b/nextjs/components/Pages/Feed/utilities/selection.ts
@@ -1,0 +1,95 @@
+import { Selections } from '../types';
+
+function getCheckedSelections(selections: Selections): Selections {
+  const result: Selections = {};
+  for (const key in selections) {
+    const selection = selections[key];
+    if (selection.checked) {
+      result[key] = { ...selection };
+    }
+  }
+  return result;
+}
+
+function getIndexes(
+  selections: Selections,
+  current: number
+): {
+  lowest: number;
+  highest: number;
+  current: number;
+} {
+  const keys = Object.keys(selections);
+  const length = keys.length;
+  if (length === 0) {
+    return {
+      lowest: 0,
+      highest: 0,
+      current,
+    };
+  }
+  const indexes = [];
+  for (const key in selections) {
+    const selection = selections[key];
+    indexes.push(selection.index);
+  }
+  return {
+    lowest: Math.min.apply(Math, indexes),
+    highest: Math.max.apply(Math, indexes),
+    current,
+  };
+}
+
+export function manageSelections({
+  id,
+  checked,
+  index,
+  selections,
+  ids,
+  isShiftPressed,
+}: {
+  id: string;
+  checked: boolean;
+  index: number;
+  selections: Selections;
+  ids: string[];
+  isShiftPressed: boolean;
+}): Selections {
+  selections = getCheckedSelections(selections);
+  if (isShiftPressed) {
+    let { lowest, highest, current } = getIndexes(selections, index);
+
+    if (lowest < current && highest > current) {
+      return selections;
+    } else if (lowest < current) {
+      const result: Selections = {};
+      for (let i = lowest, ilen = current; i <= ilen; i++) {
+        const id = ids[i];
+        result[id] = { checked, index: i };
+      }
+      return result;
+    } else if (highest > current) {
+      const result: Selections = {};
+      for (let i = current, ilen = highest; i <= ilen; i++) {
+        const id = ids[i];
+        result[id] = { checked, index: i };
+      }
+      return result;
+    }
+    return selections;
+  }
+
+  const result: Selections = {};
+  if (checked) {
+    result[id] = { checked, index };
+  }
+  for (const key in selections) {
+    if (key !== id) {
+      const selection = selections[key];
+      if (selection.checked) {
+        result[key] = { ...selections[key] };
+      }
+    }
+  }
+  return result;
+}

--- a/nextjs/hooks/keyboard.tsx
+++ b/nextjs/hooks/keyboard.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+export default function useKeyboard() {
+  const [isShiftPressed, setShiftPressed] = useState(false);
+
+  const onKey = (event: KeyboardEvent) => {
+    setShiftPressed(event.shiftKey);
+    return true;
+  };
+
+  useEffect(() => {
+    document.addEventListener('keyup', onKey);
+    document.addEventListener('keydown', onKey);
+
+    return () => {
+      document.removeEventListener('keyup', onKey);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, []);
+
+  return { isShiftPressed };
+}

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "jest --coverage",
     "test:integration": "dotenv -e .env.test -- jest -i -c jest.config.integration.js",
     "db:migrate": "npx prisma generate && npx prisma migrate dev",
-    "db:migrate:test": "dotenv -e .env.test -- npx prisma migrate deploy",
+    "db:migrate:test": "dotenv -e .env.test -- npx prisma generate && npx prisma migrate dev",
     "db:seed": "ts-node --skip-project bin/seed.ts",
     "script:sync:discord": "ts-node -P tsconfig.commonjs.json bin/discord-sync/index.ts",
     "script:sync:slack": "ts-node -P tsconfig.commonjs.json bin/slack-sync/index.ts",


### PR DESCRIPTION
## Overview

Selecting multiple options in the feed is time consuming. Shift key should allow you to select multiple options at once.

This PR adds a basic support and handles most obvious cases. I didn't get too deep into it so not adding a strong test suite yet, we might want to tweak it in the future.

Next step would be to improve it and make checkbox are bigger, to make it easier to select rows.

https://user-images.githubusercontent.com/2088208/196877826-5bd0e4eb-8b48-43d2-b070-f39657a7a358.mov

