### PR TITLE
Draggable channel rows

### DIFF
--- a/nextjs/components/Channel/ChannelGrid/index.tsx
+++ b/nextjs/components/Channel/ChannelGrid/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import CustomLink from '../../Link/CustomLink';
 import { SerializedThread } from '../../../serializers/thread';
 import ChannelRow from '../ChannelRow';
@@ -18,6 +17,7 @@ export default function ChannelGrid({
   onPin,
   onReaction,
   onMerge,
+  onDrop,
 }: {
   threads: SerializedThread[];
   permissions: Permissions;
@@ -39,6 +39,7 @@ export default function ChannelGrid({
     active: boolean;
   }): void;
   onMerge?(threadId: string): void;
+  onDrop?({ from, to }: { from: string; to: string }): void;
 }) {
   return (
     <>
@@ -47,12 +48,9 @@ export default function ChannelGrid({
         .map((thread, index) => {
           const { incrementId, slug } = thread;
           return (
-            <li
-              key={`feed-${incrementId}-${index}`}
-              className={classNames(styles.li)}
-            >
+            <li key={`feed-${incrementId}-${index}`} className={styles.li}>
               {isBot ? (
-                <div className="px-4 py-4">
+                <>
                   <CustomLink
                     isSubDomainRouting={isSubDomainRouting}
                     communityName={settings.communityName}
@@ -68,9 +66,9 @@ export default function ChannelGrid({
                       currentUser={currentUser}
                     />
                   </CustomLink>
-                </div>
+                </>
               ) : (
-                <div className="px-4 py-4" onClick={() => onClick(incrementId)}>
+                <div onClick={() => onClick(incrementId)}>
                   <ChannelRow
                     thread={thread}
                     permissions={permissions}
@@ -80,6 +78,7 @@ export default function ChannelGrid({
                     onPin={onPin}
                     onReaction={onReaction}
                     onMerge={index > 0 ? onMerge : undefined}
+                    onDrop={onDrop}
                   />
                 </div>
               )}

--- a/nextjs/components/Channel/ChannelRow/DraggableRow/index.tsx
+++ b/nextjs/components/Channel/ChannelRow/DraggableRow/index.tsx
@@ -1,0 +1,78 @@
+import React, { createRef } from 'react';
+
+interface Props {
+  className?: string;
+  overClassName: string;
+  draggable: boolean;
+  children: React.ReactNode;
+  id: string;
+  onDrop?({ from, to }: { from: string; to: string }): void;
+}
+
+export default function DraggableRow({
+  id,
+  className,
+  overClassName,
+  draggable,
+  children,
+  onDrop,
+}: Props) {
+  const ref = createRef<HTMLDivElement>();
+  if (!draggable || !onDrop) {
+    return <div className={className}>{children}</div>;
+  }
+  function handleDragStart(event: React.DragEvent) {
+    event.dataTransfer.setData('text', id);
+  }
+
+  function handleDragOver(event: React.DragEvent) {
+    event?.preventDefault();
+    return false;
+  }
+
+  function handleDragEnter(event: React.DragEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    const node = ref.current as HTMLDivElement;
+    node.classList.add(overClassName);
+  }
+
+  function handleDragLeave() {
+    const node = ref.current as HTMLDivElement;
+    node.classList.remove(overClassName);
+  }
+
+  function handleDragEnd() {
+    const node = ref.current as HTMLDivElement;
+    node.classList.remove(overClassName);
+  }
+
+  function handleDrop(event: React.DragEvent) {
+    const node = ref.current as HTMLDivElement;
+    node.classList.remove(overClassName);
+    const data = event.dataTransfer.getData('text');
+    if (data === id) {
+      return event.stopPropagation();
+    }
+    return onDrop?.({
+      from: data,
+      to: id,
+    });
+  }
+
+  return (
+    <div
+      className={className}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragEnd={handleDragEnd}
+      onDrop={handleDrop}
+      draggable
+      ref={ref}
+    >
+      {children}
+    </div>
+  );
+}

--- a/nextjs/components/Channel/ChannelRow/index.module.scss
+++ b/nextjs/components/Channel/ChannelRow/index.module.scss
@@ -1,5 +1,21 @@
 @import 'styles/colors.scss';
 
 .container {
+  align-items: center;
+  display: flex;
   position: relative;
+  padding: 1rem;
+}
+
+.over {
+  background: $color-gray-100;
+  cursor: move;
+}
+
+.over * {
+  pointer-events: none;
+}
+
+.content {
+  width: 100%;
 }

--- a/nextjs/components/Channel/ChannelRow/index.tsx
+++ b/nextjs/components/Channel/ChannelRow/index.tsx
@@ -1,3 +1,4 @@
+import DraggableRow from 'components/Channel/ChannelRow/DraggableRow';
 import Avatars from '../../Avatars';
 import { users } from '@prisma/client';
 import type { Settings } from 'serializers/account/settings';
@@ -26,6 +27,7 @@ export default function ChannelRow({
   onPin,
   onReaction,
   onMerge,
+  onDrop,
 }: {
   thread: SerializedThread;
   permissions: Permissions;
@@ -45,44 +47,54 @@ export default function ChannelRow({
     active: boolean;
   }): void;
   onMerge?(threadId: string): void;
+  onDrop?({ from, to }: { from: string; to: string }): void;
 }) {
   const { messages } = thread;
   let users = messages.map((m) => m.author).filter(Boolean) as users[];
   const authors = uniqueUsers(users);
   const oldestMessage = messages[0];
+
   return (
-    <div className={styles.container}>
-      <Row
-        thread={thread}
-        message={oldestMessage}
-        isSubDomainRouting={isSubDomainRouting}
-        settings={settings}
-        permissions={permissions}
-        currentUser={currentUser}
-        onPin={onPin}
-        onReaction={onReaction}
-        onMerge={onMerge}
-      >
-        {messages.length > 1 && (
-          <div className="flex flex-row items-center pt-2 pr-2">
-            <div className="text-sm text-gray-400 flex flex-row items-center">
-              <Avatars
-                size="sm"
-                users={
-                  authors.map((a) => ({
-                    src: a.profileImageUrl,
-                    alt: a.displayName,
-                    text: (a.displayName || '?').slice(0, 1).toLowerCase(),
-                  })) || []
-                }
-              />
-              <div className="px-2 text-blue-800">
-                {messages.length - 1} replies
+    <DraggableRow
+      id={thread.id}
+      className={styles.container}
+      draggable={permissions.manage}
+      overClassName={styles.over}
+      onDrop={onDrop}
+    >
+      <div className={styles.content}>
+        <Row
+          thread={thread}
+          message={oldestMessage}
+          isSubDomainRouting={isSubDomainRouting}
+          settings={settings}
+          permissions={permissions}
+          currentUser={currentUser}
+          onPin={onPin}
+          onReaction={onReaction}
+          onMerge={onMerge}
+        >
+          {messages.length > 1 && (
+            <div className="flex flex-row items-center pt-2 pr-2">
+              <div className="text-sm text-gray-400 flex flex-row items-center">
+                <Avatars
+                  size="sm"
+                  users={
+                    authors.map((a) => ({
+                      src: a.profileImageUrl,
+                      alt: a.displayName,
+                      text: (a.displayName || '?').slice(0, 1).toLowerCase(),
+                    })) || []
+                  }
+                />
+                <div className="px-2 text-blue-800">
+                  {messages.length - 1} replies
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </Row>
-    </div>
+          )}
+        </Row>
+      </div>
+    </DraggableRow>
   );
 }

--- a/nextjs/components/Channel/sendMessageWrapper.tsx
+++ b/nextjs/components/Channel/sendMessageWrapper.tsx
@@ -74,13 +74,13 @@ export function sendMessageWrapper({
     }
     const imitation: SerializedThread = {
       id: uuid(),
-      sentAt: new Date().toString(),
-      lastReplyAt: new Date().toString(),
+      sentAt: new Date().getTime().toString(),
+      lastReplyAt: new Date().getTime().toString(),
       messages: [
         {
           id: 'imitation-message-id',
           body: message,
-          sentAt: new Date().toString(),
+          sentAt: new Date().getTime().toString(),
           usersId: 'imitation-user-id',
           mentions: allUsers,
           attachments: [],

--- a/nextjs/components/Channel/sendThreadMessageWrapper.tsx
+++ b/nextjs/components/Channel/sendThreadMessageWrapper.tsx
@@ -70,7 +70,7 @@ export function sendThreadMessageWrapper({
     const imitation: SerializedMessage = {
       id: uuid(),
       body: message,
-      sentAt: new Date().toString(),
+      sentAt: new Date().getTime().toString(),
       usersId: currentUser.id,
       mentions: allUsers,
       attachments: [],

--- a/nextjs/components/Pages/Feed/Content/sendMessageWrapper.tsx
+++ b/nextjs/components/Pages/Feed/Content/sendMessageWrapper.tsx
@@ -71,7 +71,7 @@ export function sendMessageWrapper({
     const imitation: SerializedMessage = {
       id: uuid(),
       body: message,
-      sentAt: new Date().toString(),
+      sentAt: new Date().getTime().toString(),
       usersId: currentUser.id,
       mentions: allUsers,
       attachments: [],

--- a/nextjs/components/Pages/ThreadPage/Content/sendMessageWrapper.tsx
+++ b/nextjs/components/Pages/ThreadPage/Content/sendMessageWrapper.tsx
@@ -66,7 +66,7 @@ export function sendMessageWrapper({
     const imitation: SerializedMessage = {
       id: uuid(),
       body: message,
-      sentAt: new Date().toString(),
+      sentAt: new Date().getTime().toString(),
       usersId: currentUser.id,
       mentions: allUsers,
       attachments: [],

--- a/nextjs/styles/colors.scss
+++ b/nextjs/styles/colors.scss
@@ -4,3 +4,13 @@ $color-tertiary: #25cde8;
 
 $color-border: #e5e7eb;
 $color-background: #ffffff;
+
+$color-gray-100: #f5f5f5;
+$color-gray-200: #dcdcdc;
+$color-gray-300: #c8c8c8;
+$color-gray-400: #b0b0b0;
+$color-gray-500: #989898;
+$color-gray-600: #787878;
+$color-gray-700: #606060;
+$color-gray-800: #404040;
+$color-gray-900: #202020;


### PR DESCRIPTION
Users who have the `manage` permission (admins) are able to merge threads. This PR gives them the possibility to drag and drop channel rows.

Dragging a channel row on top of another row merges them together. The messages are sorted by the sentAt field.

We might want to introduce a `are you sure?` confirmation dialog at some point depending on the feedback.

https://user-images.githubusercontent.com/2088208/197514695-e6e82abe-c79c-4606-bfe2-8e9c557b5056.mov

