### PR TITLE
Simplify the interface of avatars and support additional letters

### DIFF
--- a/nextjs/components/Avatar/index.test.tsx
+++ b/nextjs/components/Avatar/index.test.tsx
@@ -12,6 +12,11 @@ describe('Avatar', () => {
     expect(container.querySelector('.md')).toBeInTheDocument();
   });
 
+  it('changes the text into a letter', () => {
+    const { container } = render(<Avatar text="John" />);
+    expect(container).toHaveTextContent('j');
+  });
+
   describe('when size is set to sm', () => {
     it('renders size classes', () => {
       const { container } = render(<Avatar text="a" size="sm" />);

--- a/nextjs/components/Avatar/index.tsx
+++ b/nextjs/components/Avatar/index.tsx
@@ -3,11 +3,11 @@ import classNames from 'classnames';
 import Image from 'next/image';
 import styles from './index.module.scss';
 import { normalizeUrl } from 'utilities/url';
+import { getLetter } from './utilities/string';
 
 interface Props {
   src?: string | null;
-  alt?: string | null;
-  text?: string;
+  text?: string | null;
   size?: Size;
   shadow?: Shadow;
 }
@@ -28,8 +28,10 @@ function dimensions(size?: Size) {
   }
 }
 
-function Avatar({ src, alt, text = 'u', size, shadow }: Props) {
+function Avatar({ src, text = 'u', size, shadow }: Props) {
   const [hasError, setHasError] = useState(false);
+
+  const letter = getLetter(text || '');
 
   return (
     <>
@@ -39,7 +41,7 @@ function Avatar({ src, alt, text = 'u', size, shadow }: Props) {
             [styles.shadow]: shadow === 'sm',
           })}
         >
-          {text}
+          {letter}
         </div>
       ) : (
         <div
@@ -53,7 +55,7 @@ function Avatar({ src, alt, text = 'u', size, shadow }: Props) {
             onError={() => {
               setHasError(true);
             }}
-            alt={alt || 'avatar'}
+            alt={text || 'avatar'}
             height={dimensions(size)}
             width={dimensions(size)}
           />

--- a/nextjs/components/Avatar/utilities/string.ts
+++ b/nextjs/components/Avatar/utilities/string.ts
@@ -1,0 +1,11 @@
+function isLetter(character: string): boolean {
+  return character.toLowerCase() !== character.toUpperCase();
+}
+
+export function getLetter(text: string): string {
+  const character = text.trim().slice(0, 1).toLowerCase();
+  if (isLetter(character)) {
+    return character;
+  }
+  return 'u';
+}

--- a/nextjs/components/Avatar/utilities/strint.test.ts
+++ b/nextjs/components/Avatar/utilities/strint.test.ts
@@ -1,0 +1,41 @@
+import { getLetter } from './string';
+
+describe('getLetter', () => {
+  it('returns the first letter, lowercased', () => {
+    expect(getLetter('Anna')).toEqual('a');
+    expect(getLetter('Ben')).toEqual('b');
+    expect(getLetter('Ceslav')).toEqual('c');
+    expect(getLetter('Daana')).toEqual('d');
+    expect(getLetter('Emil')).toEqual('e');
+    expect(getLetter('Faakhir')).toEqual('f');
+    expect(getLetter('Gaadhi')).toEqual('g');
+    expect(getLetter('Iaicchik')).toEqual('i');
+    expect(getLetter('John')).toEqual('j');
+    expect(getLetter('Kam')).toEqual('k');
+    expect(getLetter('Sandro')).toEqual('s');
+    expect(getLetter('Thomas')).toEqual('t');
+    expect(getLetter('Quentin')).toEqual('q');
+  });
+
+  it('returns the first letter, lowercased, of special characters', () => {
+    expect(getLetter('Łukasz')).toEqual('ł');
+    expect(getLetter('Øyvind')).toEqual('ø');
+    expect(getLetter('Żaneta')).toEqual('ż');
+  });
+
+  it('trims the display name', () => {
+    expect(getLetter('   John   ')).toEqual('j');
+  });
+
+  describe('when display name starts with a number', () => {
+    it('returns `u` as the letter', () => {
+      expect(getLetter('1Tom')).toEqual('u');
+    });
+  });
+
+  describe('when display name starts with a chinese letter', () => {
+    it('returns `u` as the letter', () => {
+      expect(getLetter('孫')).toEqual('u');
+    });
+  });
+});

--- a/nextjs/components/Avatars/index.tsx
+++ b/nextjs/components/Avatars/index.tsx
@@ -5,8 +5,7 @@ import classNames from 'classnames';
 
 interface AvatarType {
   src?: string | null;
-  alt?: string | null;
-  text: string;
+  text?: string | null;
 }
 
 interface Props {
@@ -23,7 +22,12 @@ export default function Avatars({ users, size }: Props) {
     <div className={styles.group}>
       {avatars.map((user, index) => (
         <div key={`${user.text}-${index}`} className={styles.item}>
-          <Avatar key={`${index}-avatar`} {...user} size={size} />
+          <Avatar
+            key={`${index}-avatar`}
+            text={user.text}
+            src={user.src}
+            size={size}
+          />
         </div>
       ))}
       {users.length > 2 && (

--- a/nextjs/components/Channel/ChannelRow/index.tsx
+++ b/nextjs/components/Channel/ChannelRow/index.tsx
@@ -82,8 +82,7 @@ export default function ChannelRow({
                   users={
                     authors.map((a) => ({
                       src: a.profileImageUrl,
-                      alt: a.displayName,
-                      text: (a.displayName || '?').slice(0, 1).toLowerCase(),
+                      text: a.displayName,
                     })) || []
                   }
                 />

--- a/nextjs/components/Message/Row/index.tsx
+++ b/nextjs/components/Message/Row/index.tsx
@@ -56,11 +56,8 @@ export function Row({
         {!isPreviousMessageFromSameUser && (
           <Avatar
             size="lg"
-            alt={message.author?.displayName || 'avatar'}
             src={message.author?.profileImageUrl}
-            text={(message.author?.displayName || '?')
-              .slice(0, 1)
-              .toLowerCase()}
+            text={message.author?.displayName}
           />
         )}
       </div>

--- a/nextjs/components/Pages/Feed/Row/index.tsx
+++ b/nextjs/components/Pages/Feed/Row/index.tsx
@@ -43,11 +43,8 @@ export default function Row({
         <div className={styles.body} onClick={onClick}>
           <Avatar
             size="md"
-            alt={message.author?.displayName || 'avatar'}
             src={message.author?.profileImageUrl}
-            text={(message.author?.displayName || '?')
-              .slice(0, 1)
-              .toLowerCase()}
+            text={message.author?.displayName}
           />
           <div>
             {channel && (

--- a/nextjs/components/layout/PageLayout/Header/UserAvatar/index.tsx
+++ b/nextjs/components/layout/PageLayout/Header/UserAvatar/index.tsx
@@ -56,11 +56,8 @@ export default function UserAvatar({ currentUser, onProfileChange }: Props) {
                 <Avatar
                   size="md"
                   shadow="none"
-                  alt={currentUser.displayName || 'avatar'}
                   src={currentUser.profileImageUrl}
-                  text={(currentUser.displayName || 'u')
-                    .slice(0, 1)
-                    .toLowerCase()}
+                  text={currentUser.displayName}
                 />
               </Menu.Button>
             </div>

--- a/nextjs/components/search/Suggestion/index.tsx
+++ b/nextjs/components/search/Suggestion/index.tsx
@@ -25,9 +25,8 @@ export default function Suggestion({
       <div className={styles.header}>
         <Avatar
           size="sm"
-          src={user?.profileImageUrl || ''}
-          alt={user?.displayName || ''}
-          text={(user?.displayName || '?').slice(0, 1).toLowerCase()}
+          src={user?.profileImageUrl}
+          text={user?.displayName}
         />
         <div className={styles.text}>
           <strong>{user?.displayName || 'user'}</strong>


### PR DESCRIPTION
This PR achieves few things:

- [x] consistent avatar text display when text is empty (`u` vs `?`)
- [x] supporting more letters for avatars (e.g. `Ł` or `Ø`)
- [x] simpler avatar interface (letter is deduced inside and you don't need to send `alt` anymore)

Nice to have:

- [ ] we should support e.g. chinese, japanese and other non latin characters, not sure how to detect that right now

Next steps:

Going to work on custom colors per letter in the next PR.