### PR TITLE
Custom avatar colors

### DIFF
--- a/nextjs/components/Avatar/index.module.scss
+++ b/nextjs/components/Avatar/index.module.scss
@@ -20,8 +20,7 @@
 .image {
   display: block;
   border-radius: 50%;
-  height: 36px;
-  border: 2px solid #fff !important;
+  height: 38px;
 }
 
 .placeholder {
@@ -29,10 +28,9 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  border: 2px solid $color-primary;
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
+  width: 38px;
+  min-width: 38px;
+  height: 38px;
   text-align: center;
   text-transform: lowercase;
   line-height: 32px;
@@ -53,7 +51,6 @@
   min-width: 26px;
   height: 26px;
   line-height: 26px;
-  border: none;
   font-size: 12px;
   font-weight: 500;
 }
@@ -63,5 +60,64 @@
   min-width: 38px;
   height: 38px;
   line-height: 38px;
-  border: none;
+}
+
+.color-red {
+  background: #ffebee;
+  color: #b71c1c;
+}
+
+.color-magenta {
+  background: #ffe8f0;
+  color: #a20d41;
+}
+
+.color-purple {
+  background: #f3e5f5;
+  color: #4a148c;
+}
+
+.color-indigo {
+  background-color: #e8eaf6;
+  color: #1a237e;
+}
+
+.color-blue {
+  background-color: #e3f2fd;
+  color: #0d47a1;
+}
+
+.color-cyan {
+  background-color: #e0f7fa;
+  color: #006064;
+}
+
+.color-teal {
+  background-color: #e0f2f1;
+  color: #004d40;
+}
+
+.color-green {
+  background-color: #e9f5e9;
+  color: #305332;
+}
+
+.color-lime {
+  background-color: #f5facb;
+  color: #645b0c;
+}
+
+.color-mustard {
+  background-color: #fff9de;
+  color: #845c07;
+}
+
+.color-orange {
+  background-color: #fdeee5;
+  color: #a22d09;
+}
+
+.color-brown {
+  background-color: #f5e1d4;
+  color: #5a1500;
 }

--- a/nextjs/components/Avatar/index.tsx
+++ b/nextjs/components/Avatar/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Image from 'next/image';
 import styles from './index.module.scss';
 import { normalizeUrl } from 'utilities/url';
+import { getColor } from './utilities/color';
 import { getLetter } from './utilities/string';
 
 interface Props {
@@ -29,16 +30,18 @@ function dimensions(size?: Size) {
 }
 
 function Avatar({ src, text = 'u', size, shadow }: Props) {
-  const [hasError, setHasError] = useState(false);
+  const [error, setError] = useState(false);
 
   const letter = getLetter(text || '');
+  const color = getColor(letter);
 
   return (
     <>
-      {!src || hasError ? (
+      {!src || error ? (
         <div
           className={classNames(styles.placeholder, size && styles[size], {
             [styles.shadow]: shadow === 'sm',
+            [styles[`color-${color}`]]: color,
           })}
         >
           {letter}
@@ -53,7 +56,7 @@ function Avatar({ src, text = 'u', size, shadow }: Props) {
             className={classNames(styles.image, size && styles[size])}
             src={normalizeUrl(src)}
             onError={() => {
-              setHasError(true);
+              setError(true);
             }}
             alt={text || 'avatar'}
             height={dimensions(size)}

--- a/nextjs/components/Avatar/utilities/color.ts
+++ b/nextjs/components/Avatar/utilities/color.ts
@@ -1,0 +1,61 @@
+// We have only 12 color schemes available right now
+// please note that this only includes letters of the English alphabet
+// Ł, Ż etc. are not supported yet
+
+export function getColor(character: string): string | null {
+  switch (character) {
+    case 'a':
+      return 'red';
+    case 'b':
+      return 'magenta';
+    case 'c':
+      return 'purple';
+    case 'd':
+      return 'indigo';
+    case 'e':
+      return 'blue';
+    case 'f':
+      return 'cyan';
+    case 'g':
+      return 'teal';
+    case 'h':
+      return 'green';
+    case 'i':
+      return 'lime';
+    case 'j':
+      return 'mustard';
+    case 'k':
+      return 'orange';
+    case 'l':
+      return 'brown';
+    case 'm':
+      return 'red';
+    case 'n':
+      return 'magenta';
+    case 'o':
+      return 'purple';
+    case 'p':
+      return 'indigo';
+    case 'q':
+      return 'blue';
+    case 'r':
+      return 'cyan';
+    case 's':
+      return 'teal';
+    case 't':
+      return 'green';
+    case 'u':
+      return 'lime';
+    case 'v':
+      return 'mustard';
+    case 'w':
+      return 'orange';
+    case 'x':
+      return 'brown';
+    case 'y':
+      return 'red';
+    case 'z':
+      return 'magenta';
+  }
+  return null;
+}


### PR DESCRIPTION
The colors are taken from the design, which is available here:

https://www.figma.com/file/sfxC33Y8jzZdF0rhJ2rEbI/Linen-UI-Pages

There are only 12 color sets available, but we can add more later.

I've checked few of these with a contrast checking tool and it seemed OK, but there's definitely room for improvement for readability here.

I'm not a designer though so I'll just use what's there, it's a bit better what we have now anyway.

## Next steps

- [ ] support a wider variety of letters for custom colors

## Other ideas

- [ ] allow users to pick their own (?)