### PR TITLE
Upload avatar improvements

### DIFF
--- a/apps/web/jest.config.integration.js
+++ b/apps/web/jest.config.integration.js
@@ -10,6 +10,10 @@ const config = {
   // coverageDirectory: 'coverage',
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testMatch: ['**/?(*.)+(ispec|itest).[tj]s?(x)'],
+  moduleNameMapper: {
+    '@linen/(.*)/(.*)': '<rootDir>/../../packages/$1/dist/$2',
+    '@linen/(.*)': '<rootDir>/../../packages/$1',
+  },
 };
 
 module.exports = createJestConfig({ ...customJestConfig, ...config });

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -15,9 +15,7 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   moduleNameMapper: {
-    '@linen/utilities/debounce':
-      '<rootDir>/../../packages/utilities/dist/debounce.js',
-    '@linen/hooks/mode': '<rootDir>/../../packages/hooks/dist/mode.js',
+    '@linen/(.*)/(.*)': '<rootDir>/../../packages/$1/dist/$2',
     '@linen/(.*)': '<rootDir>/../../packages/$1',
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/apps/web/services/session/index.ts
+++ b/apps/web/services/session/index.ts
@@ -38,6 +38,17 @@ export default class Session {
     return null;
   }
 
+  static async auth(
+    request: GetServerSidePropsContext['req'] | NextApiRequest,
+    response: GetServerSidePropsContext['res'] | NextApiResponse
+  ) {
+    const session = await Session.find(request, response);
+    if (session && session.user && session.user.email) {
+      return findAuthByEmail(session.user.email);
+    }
+    return null;
+  }
+
   static async token(
     req: GetServerSidePropsContext['req'] | NextApiRequest
   ): Promise<JWT | null> {


### PR DESCRIPTION
In a scenario of user belonging to multiple communities, there will be multiple db users related to a single auth. The naming is a bit confusing so it would be great to improve it in the future.

This story updates the profile image on all users of an auth instead of a single one.