### PR TITLE
LINENOSS-2 - Move metrics under settings in the navbar

### DIFF
--- a/apps/web/components/NavBar/Desktop/index.tsx
+++ b/apps/web/components/NavBar/Desktop/index.tsx
@@ -187,13 +187,7 @@ export default function DesktopNavBar({
             </Nav.Item>
           </Link>
         )}
-        {permissions.manage && (
-          <Link href="/metrics">
-            <Nav.Item active={paths.metrics === router.asPath}>
-              <FiBarChart /> Metrics
-            </Nav.Item>
-          </Link>
-        )}
+
         {currentUser && permissions.chat && (
           <DMs
             {...{
@@ -288,6 +282,11 @@ export default function DesktopNavBar({
                 <FiSettings /> Integrations
               </Nav.Item>
             </Link>
+              <Link href="/metrics">
+                <Nav.Item active={paths.metrics === router.asPath}>
+                  <FiBarChart /> Metrics
+                </Nav.Item>
+              </Link>
             <Link href="/configurations">
               <Nav.Item active={paths.configurations === router.asPath}>
                 <FiFileText /> Configurations


### PR DESCRIPTION
Link to issue - https://github.com/Linen-dev/linen.dev/issues/879

Moved metrics under settings in the navbar
<img width="387" alt="Screenshot 2023-03-08 at 15 24 29" src="https://user-images.githubusercontent.com/63657008/223712662-07b05cc1-f1bb-4c89-bd5d-493007d049fe.png">

