### PR TITLE
Onboarding page improvements

### DIFF
--- a/apps/web/components/Modals/NewCommunityModal/index.tsx
+++ b/apps/web/components/Modals/NewCommunityModal/index.tsx
@@ -14,9 +14,9 @@ interface Props {
 
 export default function NewCommunityModal({ open, close }: Props) {
   return (
-    <Modal open={open} close={close} size="lg">
+    <Modal open={open} close={close} size="md">
       <div className={styles.header}>
-        <H3>Create a community</H3>
+        <H3>New community</H3>
         <Icon onClick={close}>
           <FiX />
         </Icon>

--- a/apps/web/components/Pages/Onboarding/Form/index.tsx
+++ b/apps/web/components/Pages/Onboarding/Form/index.tsx
@@ -103,47 +103,53 @@ export default function Form({ createAccount }: Props) {
   return (
     <>
       <form onSubmit={onSubmit} id="form">
+        <Label htmlFor="name">
+          Name
+          <br />
+          <span className="text-xs font-normal text-gray-700">
+            Letters, spaces and apostrophes.
+          </span>
+        </Label>
         <TextInput
           id="name"
-          label="Community name"
           required
           type="text"
-          title="Community name should only contain letters, space and apostrophe. e.g. Linen's Community"
+          title="Letters, spaces and apostrophes."
           pattern={patterns.communityName.source}
           onChange={(event: React.FocusEvent<HTMLInputElement, Element>) => {
             const name = event.target.value;
             setSuggestion(name ? slugify(name) : '');
           }}
         />
-        <span className="text-xs text-gray-700">
-          Community name should only contain letters, space and apostrophe. e.g.
-          Linen&apos;s Community
-        </span>
-        <div className="p-4"></div>
+        <div className="p-2"></div>
 
+        <Label htmlFor="slackDomain">
+          Path
+          <br />
+          <span className="text-xs font-normal text-gray-700">
+            https://linen.dev/s/
+            {suggestion || 'community-path'}
+          </span>
+        </Label>
         <TextInput
           id="slackDomain"
-          placeholder="cool-community"
-          label="What should be your community path?"
-          {...{
-            pattern: patterns.communityPath.source,
-            required: true,
-            title:
-              'Community path should start with lower case letter and could contain lower case letters, underscore, numbers and hyphens. e.g. linen-community',
-          }}
+          required
+          pattern={patterns.communityPath.source}
+          title="Lowercased letters, underscores, numbers and hyphens."
           value={suggestion}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setSuggestion(e.target.value)
           }
         />
-        <span className="text-xs text-gray-700">
-          Community path will define the url to access your community.
-          <br />
-          https://linen.dev/s/{suggestion || 'cool-community'}
-        </span>
-        <div className="p-4"></div>
+        <div className="p-2"></div>
 
-        <Label htmlFor="channelName">Add channels to your workspace</Label>
+        <Label htmlFor="channelName">
+          Channels
+          <br />
+          <span className="text-xs font-normal text-gray-700">
+            Lowercased letters, underscores, numbers and hyphens.
+          </span>
+        </Label>
         <div className="flex flex-wrap">
           {channels?.map((channel) => {
             return (
@@ -160,11 +166,8 @@ export default function Form({ createAccount }: Props) {
             id="new-channel-onboarding"
             placeholder="general"
             icon={<FiHash />}
-            {...{
-              pattern: patterns.channelName.source,
-              title:
-                'Channels name should start with lower case letter and could contain lower case letters, underscore, numbers and hyphens. e.g. announcements',
-            }}
+            pattern={patterns.channelName.source}
+            title="Lowercased letters, underscores, numbers and hyphens."
             onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
               if (event.key === 'Enter') {
                 event.preventDefault();
@@ -173,17 +176,19 @@ export default function Form({ createAccount }: Props) {
               }
             }}
           />
-          <Button onClick={() => addChannel()}>
+          <Button style={{ marginBottom: 0 }} onClick={() => addChannel()}>
             Add <FiPlus />
           </Button>
         </div>
-        <span className="text-xs text-gray-700">
-          Channels name should contain letter, underscore, numbers and hyphens.
-          e.g. announcements
-        </span>
-        <div className="p-4"></div>
+        <div className="p-2"></div>
 
-        <Label htmlFor="email">Invite members from your team</Label>
+        <Label htmlFor="email">
+          Members
+          <br />
+          <span className="text-xs font-normal text-gray-700">
+            Send invitations via email.
+          </span>
+        </Label>
         <div className="flex flex-wrap">
           {emails?.map((email) => {
             return (
@@ -210,14 +215,19 @@ export default function Form({ createAccount }: Props) {
               }
             }}
           />
-          <Button onClick={() => addEmail()}>
+          <Button style={{ marginBottom: 0 }} onClick={() => addEmail()}>
             Add <FiPlus />
           </Button>
         </div>
-        <div className="pb-4"></div>
+        <div className="pb-8"></div>
 
-        <Button type="submit" disabled={loading}>
-          Create your new community
+        <Button
+          style={{ width: '100% ' }}
+          type="submit"
+          disabled={loading}
+          weight="medium"
+        >
+          <FiPlus /> Create your community
         </Button>
       </form>
     </>

--- a/apps/web/components/Pages/Onboarding/Form/index.tsx
+++ b/apps/web/components/Pages/Onboarding/Form/index.tsx
@@ -105,14 +105,11 @@ export default function Form({ createAccount }: Props) {
       <form onSubmit={onSubmit} id="form">
         <TextInput
           id="name"
-          placeholder="Community name"
+          label="Community name"
           required
           type="text"
-          {...{
-            pattern: patterns.communityName.source,
-            title:
-              "Community name should only contain letters, space and apostrophe. e.g. Linen's Community",
-          }}
+          title="Community name should only contain letters, space and apostrophe. e.g. Linen's Community"
+          pattern={patterns.communityName.source}
           onChange={(event: React.FocusEvent<HTMLInputElement, Element>) => {
             const name = event.target.value;
             setSuggestion(name ? slugify(name) : '');

--- a/apps/web/components/Pages/Onboarding/index.tsx
+++ b/apps/web/components/Pages/Onboarding/index.tsx
@@ -4,7 +4,7 @@ import { createAccount } from 'utilities/requests';
 
 export default function OnboardingPage() {
   return (
-    <Layout header="What's the name of your community?">
+    <Layout header="New community">
       <Form createAccount={createAccount} />
     </Layout>
   );

--- a/packages/ui/src/Button/index.module.scss
+++ b/packages/ui/src/Button/index.module.scss
@@ -21,7 +21,7 @@
 }
 
 .medium {
-  font-weight: medium;
+  font-weight: 500;
 }
 
 .bold {

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   size?: 'md' | 'sm' | 'xs';
   weight?: 'bold' | 'medium' | 'normal';
   outlined?: boolean;
+  style?: object;
 }
 
 const Button = ({
@@ -36,12 +37,14 @@ const Button = ({
   size = 'sm',
   weight = 'medium',
   outlined,
+  style,
 }: Props) => {
   return (
     <button
       disabled={disabled}
       type={type}
       onClick={onClick}
+      style={style}
       className={classNames(styles.button, className, {
         [styles.block]: block,
         [styles.medium]: weight === 'medium',

--- a/packages/ui/src/Label/index.module.scss
+++ b/packages/ui/src/Label/index.module.scss
@@ -1,8 +1,10 @@
+@import '../colors.scss';
+
 .label {
-  color: rgb(55, 65, 81);
+  color: $color-gray-900;
   display: block;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25rem;
   margin-bottom: 0.25rem;
 }

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -19,6 +19,8 @@ interface Props {
   autoComplete?: string;
   autoFocus?: boolean;
   style?: object;
+  title?: string;
+  pattern?: string;
   inputRef?: React.RefObject<HTMLInputElement>;
   onChange?(event: React.ChangeEvent<HTMLInputElement>): void;
   onInput?(event: React.ChangeEvent<HTMLInputElement>): void;
@@ -49,6 +51,8 @@ function TextInput({
   onKeyUp,
   autoComplete,
   autoFocus,
+  title,
+  pattern,
   ...rest
 }: Props) {
   return (
@@ -76,6 +80,8 @@ function TextInput({
           autoComplete={autoComplete}
           autoFocus={autoFocus}
           style={style}
+          title={title}
+          pattern={pattern}
           {...rest}
         />
       </div>


### PR DESCRIPTION
I've simplified the onboarding form to be more concise. The form is now more compact and should be faster to read and easier to understand.

Next steps:
- combine input and button
- make the members section stand out a bit more

Before:

<img width="827" alt="Screenshot 2023-04-20 at 21 32 14" src="https://user-images.githubusercontent.com/2088208/233469642-8e8b2d97-05fe-4760-9d69-029edfca0e4a.png">

After:

<img width="452" alt="Screenshot 2023-04-20 at 21 32 18" src="https://user-images.githubusercontent.com/2088208/233469652-7df21535-5dd8-48ad-ad6b-be354f3492e0.png">

Before:

<img width="521" alt="Screenshot 2023-04-20 at 21 32 35" src="https://user-images.githubusercontent.com/2088208/233469655-7ec06131-0547-4952-9132-f8cbea16dc65.png">

After:

<img width="510" alt="Screenshot 2023-04-20 at 21 32 39" src="https://user-images.githubusercontent.com/2088208/233469659-a42812e0-979f-4b24-95c8-f551a8c3c769.png">
