### PR TITLE
Onboarding improvements

### DIFF
--- a/apps/web/components/Pages/Members/index.tsx
+++ b/apps/web/components/Pages/Members/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState } from 'react';
 import PageLayout from 'components/layout/PageLayout';
 import Header from './Header';
+import Avatar from '@linen/ui/Avatar';
+import Badge from '@linen/ui/Badge';
 import Button from '@linen/ui/Button';
+import Label from '@linen/ui/Label';
 import NativeSelect from '@linen/ui/NativeSelect';
 import TextInput from '@linen/ui/TextInput';
 import Toast from '@linen/ui/Toast';
 import { useRouter } from 'next/router';
 import { Roles } from '@linen/database';
-import { AiOutlineUser } from '@react-icons/all-files/ai/AiOutlineUser';
-import { AiOutlineDelete } from '@react-icons/all-files/ai/AiOutlineDelete';
+import { FiUser } from '@react-icons/all-files/fi/FiUser';
+import { FiTrash2 } from '@react-icons/all-files/fi/FiTrash2';
 
 import {
   SerializedAccount,
@@ -34,6 +37,8 @@ export interface MembersType {
   email: string | null;
   role: Roles;
   status: 'PENDING' | 'ACCEPTED' | 'UNKNOWN' | string;
+  displayName: string | null;
+  profileImageUrl: string | null;
 }
 
 function InviteMember({
@@ -44,20 +49,28 @@ function InviteMember({
   loading: boolean;
 }) {
   return (
-    <div>
-      <form onSubmit={onSubmit} className="flex flex-row gap-2">
+    <form onSubmit={onSubmit}>
+      <Label htmlFor="email">
+        Invite
+        <br />
+        <span className="text-xs font-normal text-gray-700">
+          Send invitations via email.
+        </span>
+      </Label>
+      <div className="flex flex-row gap-2">
         <div className="grow">
           <TextInput
             id="email"
-            placeholder="Invite by email"
             type="email"
+            icon={<FiUser />}
+            placeholder="user@domain.com"
             required
           />
         </div>
         <div className="shrink">
           <NativeSelect
             id="role"
-            icon={<AiOutlineUser />}
+            icon={<FiUser />}
             theme="blue"
             options={[
               { label: 'Member', value: Roles.MEMBER },
@@ -70,28 +83,8 @@ function InviteMember({
             {loading ? 'Loading...' : 'Invite member'}
           </Button>
         </div>
-      </form>
-    </div>
-  );
-}
-
-function MemberStatus({ status }: { status: string }) {
-  if (status === 'PENDING')
-    return (
-      <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-        {status}
-      </p>
-    );
-  if (status === 'ACCEPTED')
-    return (
-      <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-        {status}
-      </p>
-    );
-  return (
-    <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-grey-100 text-grey-800">
-      {status}
-    </p>
+      </div>
+    </form>
   );
 }
 
@@ -127,8 +120,7 @@ function TableMembers({
         <div className="grow mb-2">
           <TextInput
             id="filterByEmail"
-            label="Filters"
-            placeholder="Filter by Email"
+            label="Search"
             {...{
               onKeyUp: filterByEmail,
             }}
@@ -183,19 +175,24 @@ function RowMember(user: MembersType, communityId: string): JSX.Element {
   };
 
   return (
-    <li key={user.id} className="mb-1">
-      <div className="border-gray-200 border-solid border rounded-md">
-        <div className="flex justify-start items-center px-4 py-2 gap-4">
-          <p className="text-sm font-medium truncate">{user.email}</p>
-          {user.status === 'PENDING' ? (
-            <div className="flex items-center">
-              <MemberStatus status={user.status} />
-            </div>
-          ) : (
-            <></>
-          )}
+    <li key={user.id} className="mb-2">
+      <div className="border-gray-100 border-solid border rounded-md">
+        <div className="flex justify-start items-center px-2 py-2 gap-2">
+          <Avatar src={user.profileImageUrl} text={user.displayName} />
+          <p className="text-sm font-medium truncate">
+            {user.displayName}
+            {user.status === 'PENDING' && (
+              <Badge className="ml-1" type="info">
+                {user.status}
+              </Badge>
+            )}
+            <br />
+            <span className="text-xs font-normal text-gray-700">
+              {user.email}
+            </span>
+          </p>
           <div className="grow" />
-          <div className="">
+          <div>
             <NativeSelect
               id={user.id}
               value={data.role}
@@ -203,7 +200,7 @@ function RowMember(user: MembersType, communityId: string): JSX.Element {
                 onChange(e, user.status)
               }
               disabled={loading}
-              icon={<AiOutlineUser />}
+              icon={<FiUser />}
               theme="white"
               options={[
                 { label: 'Member', value: Roles.MEMBER },
@@ -230,7 +227,7 @@ function RowMember(user: MembersType, communityId: string): JSX.Element {
                     }}
                   />
                 )}
-                <AiOutlineDelete
+                <FiTrash2
                   onClick={() => setModal(true)}
                   className="cursor-pointer"
                 />

--- a/apps/web/components/Pages/Members/index.tsx
+++ b/apps/web/components/Pages/Members/index.tsx
@@ -182,8 +182,8 @@ function RowMember(user: MembersType, communityId: string): JSX.Element {
           <p className="text-sm font-medium truncate">
             {user.displayName}
             {user.status === 'PENDING' && (
-              <Badge className="ml-1" type="info">
-                {user.status}
+              <Badge className={user.displayName ? 'ml-1' : ''} type="info">
+                Pending
               </Badge>
             )}
             <br />

--- a/apps/web/mailers/InviteToJoinMailer.ts
+++ b/apps/web/mailers/InviteToJoinMailer.ts
@@ -16,7 +16,7 @@ export default class InviteToJoinMailer {
     )}`;
     return ApplicationMailer.send({
       to,
-      subject: `${inviterName} invited you to join Linen.dev`,
+      subject: `${inviterName} invited you to join the ${communityName} community on linen.dev`,
       text: content,
       html: view({ communityName, inviterName, url }),
     });

--- a/apps/web/mailers/InviteToJoinMailer.ts
+++ b/apps/web/mailers/InviteToJoinMailer.ts
@@ -1,7 +1,8 @@
 import ApplicationMailer from './ApplicationMailer';
+import view from './views/emails/invite';
 
 interface Options {
-  communityName: string | null;
+  communityName: string;
   inviterName: string;
   host: string;
   to: string;
@@ -9,6 +10,7 @@ interface Options {
 
 export default class InviteToJoinMailer {
   static async send({ inviterName, communityName, host, to }: Options) {
+    const url = `${host}/signup?email=${encodeURIComponent(to)}`;
     const content = `Join your team ${communityName} on Linen.dev and start collaborating. ${host}/signup?email=${encodeURIComponent(
       to
     )}`;
@@ -16,7 +18,7 @@ export default class InviteToJoinMailer {
       to,
       subject: `${inviterName} invited you to join Linen.dev`,
       text: content,
-      html: content,
+      html: view({ communityName, inviterName, url }),
     });
   }
 }

--- a/apps/web/mailers/views/emails/invite/index.ts
+++ b/apps/web/mailers/views/emails/invite/index.ts
@@ -10,9 +10,9 @@ export default function email({
   url: string;
 }): string {
   return layout(`
-    <h1>Join ${communityName} on Linen</h1>
-    <p>${inviterName} invited you to join ${communityName} on <a href="https://linen.dev">linen.dev</a>.</p>
-    <p>Click the link below to securely sign in.<p>
-    <p><a href='${url}'>Sign in to Linen</a></p>
+    <h1>Join ${communityName}</h1>
+    <p>${inviterName} invited you to join the <strong>${communityName}</strong> community on <a href="https://linen.dev">linen.dev</a>.</p>
+    <p>Click the link below to securely sign up.<p>
+    <p><a href='${url}'>Sign up</a></p>
   `);
 }

--- a/apps/web/mailers/views/emails/invite/index.ts
+++ b/apps/web/mailers/views/emails/invite/index.ts
@@ -1,0 +1,18 @@
+import layout from '../../layouts/default';
+
+export default function email({
+  communityName,
+  inviterName,
+  url,
+}: {
+  communityName: string;
+  inviterName: string;
+  url: string;
+}): string {
+  return layout(`
+    <h1>Join ${communityName} on Linen</h1>
+    <p>${inviterName} invited you to join ${communityName} on <a href="https://linen.dev">linen.dev</a>.</p>
+    <p>Click the link below to securely sign in.<p>
+    <p><a href='${url}'>Sign in to Linen</a></p>
+  `);
+}

--- a/apps/web/mailers/views/layouts/default.ts
+++ b/apps/web/mailers/views/layouts/default.ts
@@ -20,7 +20,7 @@ export default function layout(children: string) {
           [
             img({
               src: 'https://linen.dev/images/logo/linen.png',
-              height: '36',
+              height: '24',
               style: 'margin: 0 auto; display: block;',
             }),
             div(

--- a/apps/web/pages/api/members/index.ts
+++ b/apps/web/pages/api/members/index.ts
@@ -10,6 +10,8 @@ interface MembersType {
   email: string | null;
   role: Roles;
   status: 'PENDING' | 'ACCEPTED' | 'UNKNOWN' | string;
+  displayName: string | null;
+  profileImageUrl: string | null;
 }
 
 function serializeUsers(
@@ -31,6 +33,8 @@ function userToMember(
     email: user.auth?.email || user.displayName,
     role: user.role,
     status: 'ACCEPTED',
+    displayName: user.displayName,
+    profileImageUrl: user.profileImageUrl,
   };
 }
 
@@ -40,6 +44,8 @@ function inviteToMember({ email, status, role, id }: invites): MembersType {
     email,
     role,
     status,
+    displayName: null,
+    profileImageUrl: null,
   };
 }
 

--- a/apps/web/services/invites.ts
+++ b/apps/web/services/invites.ts
@@ -58,15 +58,17 @@ export async function createInvitation({
     });
   }
 
-  await sendInvitationByEmail({
-    email,
-    host,
-    communityName: (invite.accounts?.name ||
-      invite.accounts?.discordDomain ||
-      invite.accounts?.slackDomain)!,
-    inviterName: (invite.createdBy?.displayName ||
-      invite.createdBy?.auth?.email)!,
-  });
+  if (invite.accounts) {
+    await sendInvitationByEmail({
+      email,
+      host,
+      communityName: (invite.accounts.name ||
+        invite.accounts.discordDomain ||
+        invite.accounts.slackDomain)!,
+      inviterName: (invite.createdBy?.displayName ||
+        invite.createdBy?.auth?.email)!,
+    });
+  }
 
   return { status: 200, message: 'invitation sent' };
 }
@@ -77,7 +79,7 @@ async function sendInvitationByEmail({
   communityName,
   inviterName,
 }: {
-  communityName: string | null;
+  communityName: string;
   email: string;
   host: string;
   inviterName: string;

--- a/packages/ui/src/NativeSelect/index.module.scss
+++ b/packages/ui/src/NativeSelect/index.module.scss
@@ -19,6 +19,7 @@
   background-size: 1.5em 1.5em;
   cursor: pointer;
   font-size: 0.875rem;
+  font-weight: 500;
   line-height: 1.25rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -65,7 +66,7 @@
   border-color: #1149e0;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   color: white;
-  font-weight: bold;
+  font-weight: 500;
 }
 
 .blue .select:hover,
@@ -83,7 +84,7 @@
   border-color: $color-gray-100;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23000000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   color: black;
-  font-weight: bold;
+  font-weight: 500;
 }
 
 .gray .select:hover {


### PR DESCRIPTION
## Emails

Our onboarding process includes sending emails to people. Our invitation email was unstyled so I've added an html version of it, which should help us gain more trust.

Next steps:

- styled button (across all emails)

Before:

<img width="1364" alt="Screenshot 2023-04-21 at 12 42 48" src="https://user-images.githubusercontent.com/2088208/233616865-1f477f08-6450-4543-8375-92313ab3ba18.png">

After:

<img width="1377" alt="Screenshot 2023-04-21 at 12 42 39" src="https://user-images.githubusercontent.com/2088208/233616873-052b1e77-6987-4c53-9a08-14d3f24e72ea.png">

## Members page

Members page had few problems:
- invitation section was not obvious
- users in the list didn't have all available information
- styling was a bit broken

Next steps:
Improve the invitation so you can invite multiple people at once, without a page reload. Current flow is really slow and annoying.

Before:

<img width="1470" alt="Screenshot 2023-04-21 at 12 42 57" src="https://user-images.githubusercontent.com/2088208/233616876-a7e4dcad-b83c-4e5d-8682-d33cea259716.png">

After:

<img width="1464" alt="Screenshot 2023-04-21 at 12 43 03" src="https://user-images.githubusercontent.com/2088208/233616881-a3b01c29-5d78-46ea-b5f5-5b9360521a24.png">
