### PR TITLE
Branding page improvements

### DIFF
--- a/apps/web/bin/factory/communities/linen/index.ts
+++ b/apps/web/bin/factory/communities/linen/index.ts
@@ -14,6 +14,8 @@ export default async function createLinenCommunity() {
       brandColor: '#000000',
       slackDomain: 'linen',
       logoUrl: 'https://static.main.linendev.com/linen-white-logo.svg',
+      logoSquareUrl:
+        'https://static.main.linendev.com/logos/logo05dab315-0b75-415b-aca4-f56a1867f045.png',
       faviconUrl: 'https://www.linen.dev/favicon.ico',
       chat: ChatType.MEMBERS,
       syncStatus: 'DONE',

--- a/apps/web/components/Pages/Branding/LogoField/index.module.scss
+++ b/apps/web/components/Pages/Branding/LogoField/index.module.scss
@@ -1,0 +1,12 @@
+.spin {
+  animation: spin-animation 2s infinite;
+}
+
+@keyframes spin-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(359deg);
+  }
+}

--- a/apps/web/components/Pages/Branding/LogoField/index.tsx
+++ b/apps/web/components/Pages/Branding/LogoField/index.tsx
@@ -4,6 +4,9 @@ import { usePresignedUpload } from 'next-s3-upload';
 import Button from '@linen/ui/Button';
 import Label from '@linen/ui/Label';
 import { SerializedAccount } from '@linen/types';
+import { FiUploadCloud } from '@react-icons/all-files/fi/FiUploadCloud';
+import { FiLoader } from '@react-icons/all-files/fi/FiLoader';
+import styles from './index.module.scss';
 
 interface Props {
   currentCommunity: SerializedAccount;
@@ -11,6 +14,13 @@ interface Props {
   logoUrl?: string;
   header: string;
   description: string;
+  preview?({
+    logoUrl,
+    brandColor,
+  }: {
+    logoUrl: string;
+    brandColor?: string;
+  }): React.ReactNode;
 }
 
 function Description({ children }: { children: React.ReactNode }) {
@@ -23,6 +33,7 @@ export default function LogoField({
   logoUrl,
   header,
   description,
+  preview,
 }: Props) {
   let { FileInput, openFileDialog, uploadToS3, files } = usePresignedUpload();
   const isUploading = files && files.length > 0 && files[0].progress < 100;
@@ -49,21 +60,26 @@ export default function LogoField({
         <Description>{description}</Description>
       </Label>
       <FileInput onChange={handleLogoChange} />
-      {logoUrl && (
-        <img
-          alt=""
-          src={logoUrl}
-          style={{
-            backgroundColor: currentCommunity.brandColor,
-          }}
-          className={classNames('mb-2 mt-2 max-h-60')}
-        />
-      )}
+
+      {logoUrl &&
+        (preview ? (
+          preview({ logoUrl, brandColor: currentCommunity.brandColor })
+        ) : (
+          <img
+            alt=""
+            src={logoUrl}
+            style={{
+              backgroundColor: currentCommunity.brandColor,
+            }}
+            className={classNames('mb-2 mt-2 max-h-60')}
+          />
+        ))}
       <Button
         onClick={() => !isUploading && openFileDialog()}
         disabled={!currentCommunity.premium || isUploading}
       >
-        {isUploading ? 'Uploading...' : 'Upload file'}
+        {isUploading ? <FiLoader className={styles.spin} /> : <FiUploadCloud />}
+        Upload
       </Button>
     </>
   );

--- a/apps/web/components/Pages/Branding/index.tsx
+++ b/apps/web/components/Pages/Branding/index.tsx
@@ -326,6 +326,28 @@ export default function Branding({
                     });
                   }}
                   logoUrl={currentCommunity.logoSquareUrl}
+                  preview={({ logoUrl, brandColor }) => {
+                    return (
+                      <div
+                        style={{
+                          backgroundColor: brandColor,
+                          height: 36,
+                          width: 36,
+                          minWidth: 36,
+                          borderRadius: '4px',
+                          overflow: 'hidden',
+                          marginBottom: '0.5rem',
+                        }}
+                      >
+                        <img
+                          src={logoUrl}
+                          height="36"
+                          width="36"
+                          style={{ height: 36, width: 36 }}
+                        />
+                      </div>
+                    );
+                  }}
                 />
               </PremiumCard>
               <hr className="my-5" />
@@ -340,6 +362,33 @@ export default function Branding({
                     });
                   }}
                   logoUrl={currentCommunity.faviconUrl}
+                  preview={({ logoUrl, brandColor }) => {
+                    return (
+                      <div
+                        style={{
+                          backgroundColor: 'white',
+                          borderRadius: '4px',
+                          overflow: 'hidden',
+                          marginBottom: '0.5rem',
+                          border: '1px solid #e5e7eb',
+                          width: 34,
+                          height: 34,
+                          padding: '8px',
+                        }}
+                      >
+                        <img
+                          src={logoUrl}
+                          height="16"
+                          width="16"
+                          style={{
+                            display: 'block',
+                            height: 16,
+                            width: 16,
+                          }}
+                        />
+                      </div>
+                    );
+                  }}
                 />
               </PremiumCard>
               <hr className="my-5" />

--- a/apps/web/components/Pages/Branding/index.tsx
+++ b/apps/web/components/Pages/Branding/index.tsx
@@ -296,6 +296,22 @@ export default function Branding({
                     });
                   }}
                   logoUrl={currentCommunity.logoUrl}
+                  preview={({ logoUrl, brandColor }) => {
+                    return (
+                      <div
+                        style={{
+                          backgroundColor: brandColor,
+                          height: 54,
+                          display: 'flex',
+                          alignItems: 'center',
+                          padding: '0 1rem',
+                          marginBottom: '0.5rem',
+                        }}
+                      >
+                        <img src={logoUrl} height="24" style={{ height: 24 }} />
+                      </div>
+                    );
+                  }}
                 />
               </PremiumCard>
               <hr className="my-5" />


### PR DESCRIPTION
## Overview

Logos on the branding page weren't very helpful, as they didn't provide a lot of context on how the images are going to be displayed. This PR adds custom previews for logos which should solve that problem.

I've also made the Upload buttons simpler.

Before:

<img width="1723" alt="Screenshot 2023-04-21 at 16 23 29" src="https://user-images.githubusercontent.com/2088208/233660822-c746e3e3-247d-498e-8332-ca39bc9805b5.png">

After:

<img width="1707" alt="Screenshot 2023-04-21 at 16 23 34" src="https://user-images.githubusercontent.com/2088208/233660876-ae9118c1-f295-4765-a8dc-ba4fa8441e03.png">
