### PR TITLE
Fix logos

### DIFF
--- a/apps/web/components/layout/PageLayout/Header/Logo/index.tsx
+++ b/apps/web/components/layout/PageLayout/Header/Logo/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import styles from './index.module.scss';
+import { getImageWidth } from './utilities/dimensions';
 
 interface Props {
   src: string;
@@ -39,5 +40,13 @@ export default function Logo({ src, alt }: Props) {
     );
   }
 
-  return <img className={styles.logo} src={src} height="24" alt={alt} />;
+  return (
+    <img
+      className={styles.logo}
+      src={src}
+      height="24"
+      width={getImageWidth(src)}
+      alt={alt}
+    />
+  );
 }

--- a/apps/web/components/layout/PageLayout/Header/Logo/index.tsx
+++ b/apps/web/components/layout/PageLayout/Header/Logo/index.tsx
@@ -22,8 +22,7 @@ interface Props {
 function isLinenLogo(src: string): boolean {
   return (
     src === 'https://static.main.linendev.com/linen-white-logo.svg' ||
-    src ===
-      'https://static.main.linendev.com/logos/linen-white-logod4a4fd54-2892-4499-ad31-af77bee6b08f.svg'
+    src.startsWith('https://static.main.linendev.com/logos/linen-white-logo')
   );
 }
 

--- a/apps/web/components/layout/PageLayout/Header/Logo/utilities/dimensions.test.ts
+++ b/apps/web/components/layout/PageLayout/Header/Logo/utilities/dimensions.test.ts
@@ -1,0 +1,8 @@
+import { getImageWidth } from './dimensions';
+
+describe('#getImageWidth', () => {
+  it('returns the width if the url contains sizes', () => {
+    const url = 'https://foo.com/image_24x24.jpg';
+    expect(getImageWidth(url)).toEqual(24);
+  });
+});

--- a/apps/web/components/layout/PageLayout/Header/Logo/utilities/dimensions.ts
+++ b/apps/web/components/layout/PageLayout/Header/Logo/utilities/dimensions.ts
@@ -1,0 +1,135 @@
+// naively hardcoing image widths to prevent layout shifts on page loads
+// we should remove this as soon as we migrate image names with dimensions
+export function getImageWidthByUrl(src: string) {
+  if (src === 'https://static.main.linendev.com/growthbook_logo.svg') {
+    return 131;
+  }
+  if (src === 'https://static.main.linendev.com/logos/cerbos-logo.svg') {
+    return 82;
+  }
+  if (src === 'https://static.main.linendev.com/pulumi-logo.svg') {
+    return 96;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/osquery%2520sticker%2520%281%297fb9af5f-b4e4-449f-9dfd-ae4d0d0d106f.svg'
+  ) {
+    return 82;
+  }
+  if (
+    src === 'https://static.main.linendev.com/platform-engineering-logo.svg'
+  ) {
+    return 90;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/5838a945-18b3-4437-9ab1-ee7aec4e8901.svg'
+  ) {
+    return 103;
+  }
+  if (src === 'https://static.main.linendev.com/questdb-logo.svg') {
+    return 99;
+  }
+  if (src === 'https://static.main.linendev.com/orchest-logo.svg') {
+    return 112;
+  }
+  if (src === 'https://static.main.linendev.com/signoz-logo.svg') {
+    return 96;
+  }
+  if (src === 'https://static.main.linendev.com/prefect-logo.svg') {
+    return 94;
+  }
+  if (src === 'https://static.main.linendev.com/logos/acryl-logo.svg') {
+    return 88;
+  }
+  if (src === 'https://static.main.linendev.com/luna-sec-white-logo.svg') {
+    return 93;
+  }
+  if (src === 'https://static.main.linendev.com/logos/kotlin-logo.svg') {
+    return 111;
+  }
+  if (src === 'https://static.main.linendev.com/logos/calcom-logo.svg') {
+    return 110;
+  }
+  if (src === 'https://static.main.linendev.com/efabless-logo.svg') {
+    return 64;
+  }
+  if (src === 'https://static.main.linendev.com/infracost-logo.svg') {
+    return 118;
+  }
+  if (src === 'https://static.main.linendev.com/future-of-coding-logo.svg') {
+    return 140;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/c565d644-1a66-456c-afea-28dbc04ff881.svg'
+  ) {
+    return 103;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/image%2520(14)19913d85-f662-4518-a9a1-7adc1793dfd4.png'
+  ) {
+    return 24;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/dl-stacked-rev-rgb-200pxed106a3d-55a3-4be6-b3ae-266540cc26fa.png'
+  ) {
+    return 31;
+  }
+  if (src === 'https://static.main.linendev.com/flyte_lockup_on_dark.png') {
+    return 73;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/02df5b5e-1d06-49b5-8c84-c2b67ca31b10.png'
+  ) {
+    return 69;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/9531bdd8-0127-48ad-877d-a65da3f90597.png'
+  ) {
+    return 96;
+  }
+  if (
+    src === 'https://static.main.linendev.com/netsuiteprofessionals-logo.png'
+  ) {
+    return 72;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/pants-20logo-20with-20name0d38a6d9-3f5c-4614-8a58-f24fb11f86d5.png'
+  ) {
+    return 72;
+  }
+  if (
+    src ===
+    'https://static.main.linendev.com/logos/4daeef92-7139-43b6-a5af-3feb8342a30c.png'
+  ) {
+    return 92;
+  }
+  if (src === 'https://static.main.linendev.com/airbyte-logo.png') {
+    return 88;
+  }
+  return undefined;
+}
+
+export function getImageWidth(src: string) {
+  const hardcodedWidth = getImageWidthByUrl(src);
+  if (hardcodedWidth) {
+    return hardcodedWidth;
+  }
+  const parts = src.split('_');
+  const last = parts[parts.length - 1];
+  const sizes = last.split('.');
+  const dimensions = sizes[sizes.length - 2];
+  if (dimensions) {
+    const [width, height] = dimensions.split('x');
+    if (width && height) {
+      return Number(width);
+    }
+  }
+  return undefined;
+}

--- a/apps/web/components/layout/PageLayout/Header/index.tsx
+++ b/apps/web/components/layout/PageLayout/Header/index.tsx
@@ -56,6 +56,7 @@ export default function Header({
         borderBottom: `1px solid ${borderColor}`,
         borderTop: `1px solid ${brandColor}`,
         gap: '16px',
+        height: '54px',
       }}
     >
       <Link


### PR DESCRIPTION
## Overview

Firefox does not render our logos correctly, it needs both width/height properties. Lack of width also results in a layout shift. Given that most of our logos are uploaded by users, we don't really know the width before seeing the image.

## Solution

Long term solution that @sandrodesouza is working on is that we're going to include dimensions in the image size, which will also allow us to generate thumbnails more easily.

Short term solution in this PR simplify hardcodes the widths, so we fix both problems until we get the long term solution in prod.