### PR TITLE
[apps/web] preview improvements

### DIFF
--- a/packages/ui/src/GridRow/index.module.scss
+++ b/packages/ui/src/GridRow/index.module.scss
@@ -52,13 +52,12 @@
 }
 
 .header {
-  align-items: center;
+  align-items: baseline;
   color: $color-gray-600;
   display: flex;
   flex-direction: row;
   font-size: 0.75rem;
-  padding-bottom: 0.25rem;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .date {

--- a/packages/ui/src/MessageForm/index.tsx
+++ b/packages/ui/src/MessageForm/index.tsx
@@ -8,7 +8,7 @@ import Preview from '../MessagePreview';
 import FileInput from './FileInput';
 import FilesSummary from './FilesSummary';
 import { getCaretPosition, setCaretPosition } from './utilities/caret';
-import { previewable, postprocess } from '@linen/ast';
+import { postprocess } from '@linen/ast';
 import { isWhitespace } from '@linen/utilities/string';
 import { MessageFormat, SerializedUser } from '@linen/types';
 import { useUsersContext } from '@linen/contexts/Users';
@@ -298,7 +298,7 @@ function MessageForm({
           }}
         />
       )}
-      {message && preview && previewable(message) && (
+      {message && preview && (
         <Preview
           currentUser={currentUser}
           message={{

--- a/packages/ui/src/MessagePreview/index.module.scss
+++ b/packages/ui/src/MessagePreview/index.module.scss
@@ -31,11 +31,11 @@
 }
 
 .header {
-  align-items: center;
+  align-items: baseline;
   display: flex;
   flex-direction: row;
-  padding-bottom: 0.25rem;
-  gap: 0.5rem;
+  gap: 0.375rem;
+  letter-spacing: 1;
 }
 
 .date {
@@ -59,4 +59,13 @@
   display: block;
   font-size: 1px;
   z-index: 1;
+}
+
+.badge {
+  position: absolute;
+  right: 0;
+  top: 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
 }

--- a/packages/ui/src/MessagePreview/index.tsx
+++ b/packages/ui/src/MessagePreview/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Avatar from '../Avatar';
+import Badge from '../Badge';
 import Message from '../Message';
 import { SerializedMessage, SerializedUser } from '@linen/types';
 import styles from './index.module.scss';
@@ -13,6 +14,7 @@ interface Props {
 function Row({ message, currentUser }: Props) {
   return (
     <div className={styles.container}>
+      <Badge className={styles.badge}>Preview</Badge>
       <div className={styles.row}>
         <div className={styles.left}>
           <Avatar
@@ -25,7 +27,7 @@ function Row({ message, currentUser }: Props) {
             <p className={styles.username}>
               {message.author?.displayName || 'user'}
             </p>
-            <div className={styles.date}>{format(message.sentAt, 'Pp')}</div>
+            <div className={styles.date}>MM/DD/YYYY</div>
           </div>
           <div className={styles.message}>
             <Message


### PR DESCRIPTION
## Overview

One of our users pointed out that current previews are a bit confusing due to the fact that it's not obvious whether the message was sent or not, related thread is here: https://www.linen.dev/s/linen/t/10956483/it-s-cool-to-have-a-preview-for-messages-with-markdown-but-t

## Solution

To improve the UX here I made the following changes:
- add a `Preview` label in the top right corner
- change date to show the date format as a placeholder vs the current date
- show preview when message exists

Before:

<img width="536" alt="Screenshot 2023-05-01 at 14 22 30" src="https://user-images.githubusercontent.com/2088208/235451332-2c7cb778-2577-4c15-831e-512fdbbaa9b1.png">

After:

<img width="524" alt="Screenshot 2023-05-01 at 14 22 16" src="https://user-images.githubusercontent.com/2088208/235451335-c81c751c-1917-4a08-bf0d-e04a38a53dad.png">
