### PR TITLE
Mentions topbar

### DIFF
--- a/packages/ui/src/Header/index.module.scss
+++ b/packages/ui/src/Header/index.module.scss
@@ -27,6 +27,9 @@
 }
 
 @media (min-width: 1024px) {
+  .menu {
+    gap: 1rem;
+  }
   .search {
     display: block;
   }
@@ -47,5 +50,24 @@
 @media (min-width: 1024px) {
   .lgHidden {
     display: none;
+  }
+}
+
+.mention {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .mention {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .mention:hover {
+    text-decoration: underline;
   }
 }

--- a/packages/ui/src/NavBar/Desktop/index.tsx
+++ b/packages/ui/src/NavBar/Desktop/index.tsx
@@ -152,6 +152,19 @@ export default function DesktopNavBar({
     });
   };
 
+  // useEffect(() => {
+  //   let mounted = true;
+  //   setTimeout(() => {
+  //     onNewMessage({
+  //       mention_type: 'signal',
+  //       channel_id: channels[0].id,
+  //     });
+  //   }, 1000);
+  //   return () => {
+  //     mounted = false;
+  //   };
+  // }, []);
+
   useWebsockets({
     room: userId && `user:${userId}`,
     permissions,

--- a/packages/ui/src/NavBar/Desktop/index.tsx
+++ b/packages/ui/src/NavBar/Desktop/index.tsx
@@ -34,7 +34,7 @@ import AnalyticsGroup from './AnalyticsGroup';
 import EditChannelModal from '@/EditChannelModal';
 import type { ApiClient } from '@linen/api-client';
 import NewCommunityModal from '@/NewCommunityModal';
-import { FiSearch } from '@react-icons/all-files/fi/FiSearch';
+import EventEmitter from '@linen/utilities/event';
 
 interface Props {
   mode: Mode;
@@ -145,6 +145,7 @@ export default function DesktopNavBar({
         const text = `You were mentioned in #${channel.channelName}`;
         Toast.info(text);
         notify(text);
+        EventEmitter.emit('mention:new', { channel });
       }
     }
     setHighlights((highlights) => {
@@ -165,6 +166,9 @@ export default function DesktopNavBar({
   //   };
   // }, []);
 
+  // the logic for connecting to websockets should be moved to the top level container
+  // after connecting, we could use an internal event bus to pass to those events
+  // and manage the logic in internal components
   useWebsockets({
     room: userId && `user:${userId}`,
     permissions,

--- a/packages/utilities/src/event.js
+++ b/packages/utilities/src/event.js
@@ -1,17 +1,25 @@
 const EventEmitter = {
   events: {},
-  emit (name, data) {
-    if (!this.events[name]) { return }
-    this.events[name].forEach(callback => callback(data))
+  emit(name, data) {
+    if (!this.events[name]) {
+      return;
+    }
+    this.events[name].forEach((callback) => callback(data));
   },
-  on (name, callback) {
-    if (!this.events[name]) { this.events[name] = [] }
-    this.events[name].push(callback)
+  on(name, callback) {
+    if (!this.events[name]) {
+      this.events[name] = [];
+    }
+    this.events[name].push(callback);
   },
-  off (name, callback) {
-    if (!this.events[name]) { return }
-    this.events[name] = this.events[name].filter(handler => handler !== callback)
-  }
-}
+  off(name, callback) {
+    if (!this.events[name]) {
+      return;
+    }
+    this.events[name] = this.events[name].filter(
+      (handler) => handler !== callback
+    );
+  },
+};
 
-export default EventEmitter
+export default EventEmitter;


### PR DESCRIPTION
## Context

Tauri does not implement [notification.onclick](https://developer.mozilla.org/en-US/docs/Web/API/Notification/click_event) yet and we do not have enough [rust](https://www.rust-lang.org/) experience to help with the implementation, so we have to find a different way to lead the user to the right channel. [Related tauri issue is here](https://github.com/tauri-apps/tauri/issues/3698).

As a workaround, we're going to add a clickable link in the top right corner, close to where notifications show up by default.

This way we'll going to have a 2 click ux path vs a 1 click ux path, which is not ideal, but better than nothing.

I'm going to make this text dismissible with an `x` button in the next step.

<img width="1728" alt="Screenshot 2023-05-31 at 10 00 37" src="https://github.com/Linen-dev/linen.dev/assets/2088208/fa80ab46-e97b-4fe7-ac28-8bd2fafbbd11">
