### PR TITLE
Channel improvements

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -168,6 +168,7 @@
     "./ProfileForm": "./dist/ProfileForm/index.js",
     "./Progress": "./dist/Progress/index.js",
     "./ProgressModal": "./dist/ProgressModal/index.js",
+    "./Radio": "./dist/Radio/index.js",
     "./ReminderModal": "./dist/ReminderModal/index.js",
     "./Row": "./dist/Row/index.js",
     "./RowSkeleton": "./dist/RowSkeleton/index.js",
@@ -498,6 +499,9 @@
       ],
       "ProgressModal": [
         "./dist/ProgressModal/index.d.ts"
+      ],
+      "Radio": [
+        "./dist/Radio/index.d.ts"
       ],
       "ReminderModal": [
         "./dist/ReminderModal/index.d.ts"

--- a/packages/ui/src/ChannelsView/index.module.scss
+++ b/packages/ui/src/ChannelsView/index.module.scss
@@ -66,8 +66,16 @@
     }
 
     &.highlighted {
-      border-top: 1px solid var(--color-primary);
+      background: var(--color-blue-50);
+      cursor: move;
+
+      @media (prefers-color-scheme: dark) {
+        background: var(--color-blue-900);
+      }
     }
+
+
+
   }
 
   td {

--- a/packages/ui/src/ChannelsView/index.tsx
+++ b/packages/ui/src/ChannelsView/index.tsx
@@ -342,16 +342,6 @@ export default function ChannelsView({
                     <Toggle
                       checked={channel.landing}
                       onChange={(checked) => {
-                        if (channel.hidden) {
-                          return Toast.error(
-                            'You need to make the channel visible first. Otherwise noone will be able to see it'
-                          );
-                        }
-                        if (!channel.default) {
-                          return Toast.error(
-                            'You need to set the channel as default first. Otherwise first time users will not see it'
-                          );
-                        }
                         if (channel.landing && !checked) {
                           return Toast.error(
                             'Please choose a different landing channel.'
@@ -360,6 +350,8 @@ export default function ChannelsView({
                         debouncedUpdateChannel({
                           ...channel,
                           landing: checked,
+                          default: true,
+                          hidden: false,
                         });
                         setChannels((channels: SerializedChannel[]) => {
                           return channels.map((c: SerializedChannel) => {
@@ -368,6 +360,8 @@ export default function ChannelsView({
                                 return {
                                   ...c,
                                   landing: true,
+                                  default: true,
+                                  hidden: false,
                                 };
                               }
                               return {

--- a/packages/ui/src/ChannelsView/index.tsx
+++ b/packages/ui/src/ChannelsView/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import Header from './Header';
+import Radio from '@/Radio';
 import Toggle from '@/Toggle';
 import NativeSelect from '@/NativeSelect';
 import Toast from '@/Toast';
@@ -339,7 +340,7 @@ export default function ChannelsView({
                     />
                   </td>
                   <td>
-                    <Toggle
+                    <Radio
                       checked={channel.landing}
                       onChange={(checked) => {
                         if (channel.landing && !checked) {

--- a/packages/ui/src/Radio/index.module.scss
+++ b/packages/ui/src/Radio/index.module.scss
@@ -1,0 +1,40 @@
+.radio {
+  appearance: none;
+  background: var(--color-gray-200);
+  border-radius: 16px;
+  cursor: pointer;
+  display: flex;
+  height: 24px;
+  margin: 0;
+  min-width: 24px;
+  outline: none;
+  padding: 0;
+  position: relative;
+  outline: none;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  user-select: none;
+  width: 24px;
+
+  &:after {
+    background: var(--color-background);
+    border-radius: 50%;
+    content: '';
+    display: block;
+    height: 18px;
+    left: 3px;
+    position: absolute;
+    top: 3px;
+    border: 2px solid var(--color-background);
+    transition: background 0.2s ease, opacity 0.2s ease;
+    width: 18px;
+  }
+
+  &:checked {
+    background: var(--color-primary);
+  }
+
+  &:checked:after {
+    background: var(--color-primary);
+    border: 2px solid var(--color-background);
+  }
+}

--- a/packages/ui/src/Radio/index.tsx
+++ b/packages/ui/src/Radio/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames';
+import styles from './index.module.scss';
+
+interface Props {
+  checked: boolean;
+  onChange(checked: boolean): void;
+}
+
+export default function Radio({ checked, onChange }: Props) {
+  return (
+    <input
+      className={classNames(styles.radio, styles.switch)}
+      type="radio"
+      checked={checked}
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+        onChange(event.target.checked)
+      }
+    />
+  );
+}


### PR DESCRIPTION
Few minor channel page improvements:

1. Setting a landing channel automatically marks the channel as visible and default (fewer clicks for the user and less code)
2. You can select just one landing channel, so the toggle has changed to a radio to be more explicit.
3. Drag & drop styling now uses a background vs a border to be more explicit on where the channel goes after dropping

<img width="1473" alt="Screenshot 2023-07-28 at 10 46 05" src="https://github.com/Linen-dev/linen.dev/assets/2088208/e379df8f-3778-4ceb-998d-3bbccbcf98de">
<img width="1456" alt="Screenshot 2023-07-28 at 10 46 14" src="https://github.com/Linen-dev/linen.dev/assets/2088208/799406af-3ad5-4da3-b9e7-c1404a7d933e">
