### PR TITLE
Markdown link in a list fix

### DIFF
--- a/packages/ast/parse/linen/index.js
+++ b/packages/ast/parse/linen/index.js
@@ -1,19 +1,22 @@
 const tokenize = require('./tokenize');
-const split = require('./split');
+const listify = require('./listify');
 const expand = require('./expand');
+const linkify = require('./linkify');
 const normalize = require('./normalize');
 
 // Linen's message parser is a multipass parser
 // 1st pass tokenizes the input into text, code and user nodes
-// 2nd pass splits text nodes to text nodes or urls
-// 3rd pass deduces bold, italic and strike tags within text
-// 4th step normalizes tokens
+// 2nd pass finds lists
+// 3rd pass finds bold, italic and strike tags
+// 4th pass finds links
+// 5th step normalizes tokens
 
 function parse(input) {
   let tokens;
   tokens = tokenize(input);
-  tokens = split(tokens);
+  tokens = listify(tokens);
   tokens = expand(tokens);
+  tokens = linkify(tokens);
   return tokens.map(normalize);
 }
 

--- a/packages/ast/parse/linen/index.spec.js
+++ b/packages/ast/parse/linen/index.spec.js
@@ -285,9 +285,12 @@ describe('parse', () => {
     );
   });
 
-  it.skip('works for urls inside of lists', () => {
+  it('works for urls inside of lists', () => {
     expect(parse('- https://foo.com')).toEqual(
       root([list([item([url('https://foo.com')])])])
+    );
+    expect(parse('- foo https://bar.com')).toEqual(
+      root([list([item([text('foo '), url('https://bar.com')])])])
     );
   });
 });

--- a/packages/ast/parse/linen/index.spec.js
+++ b/packages/ast/parse/linen/index.spec.js
@@ -284,4 +284,10 @@ describe('parse', () => {
       root([text('foo\n'), list([item([text('bar')])], { ordered: true })])
     );
   });
+
+  it.skip('works for urls inside of lists', () => {
+    expect(parse('- https://foo.com')).toEqual(
+      root([list([item([url('https://foo.com')])])])
+    );
+  });
 });

--- a/packages/ast/parse/linen/linkify/index.js
+++ b/packages/ast/parse/linen/linkify/index.js
@@ -2,7 +2,10 @@ function splitByPattern(tokens, pattern) {
   const result = [];
   for (let index = 0, length = tokens.length; index < length; index++) {
     const token = tokens[index];
-    if (token.type === 'text') {
+    if (token.type === 'list' || token.type === 'item') {
+      token.children = splitByPattern(token.children, pattern);
+      result.push(token);
+    } else if (token.type === 'text') {
       const { value } = token;
       const matches = value.match(pattern);
 

--- a/packages/ast/parse/linen/linkify/index.js
+++ b/packages/ast/parse/linen/linkify/index.js
@@ -1,0 +1,82 @@
+function splitByPattern(tokens, pattern) {
+  const result = [];
+  for (let index = 0, length = tokens.length; index < length; index++) {
+    const token = tokens[index];
+    if (token.type === 'text') {
+      const { value } = token;
+      const matches = value.match(pattern);
+
+      if (matches) {
+        let indexes = [];
+        let needles = [];
+        let search = value.slice();
+        for (const match of matches) {
+          const start = search.indexOf(match);
+          const end = start + match.length;
+          indexes.push(start);
+          needles.push(start);
+          indexes.push(end);
+          search = search.replace(match, '_'.repeat(match.length));
+        }
+
+        if (indexes[0] !== 0) {
+          indexes.unshift(0);
+        }
+        if (indexes[indexes.length - 1] !== value.length) {
+          indexes.push(value.length);
+        }
+
+        for (let index = 0, length = indexes.length; index < length; index++) {
+          const current = indexes[index];
+          const next = indexes[index + 1];
+          if (typeof current === 'number' && typeof next === 'number') {
+            const text = value.substring(current, next);
+            if (needles.includes(current)) {
+              if (text.startsWith('[') && text.endsWith(')')) {
+                const title = text.substring(1, text.indexOf(']'));
+                const url = text.substring(
+                  text.indexOf('(') + 1,
+                  text.lastIndexOf(')')
+                );
+                result.push({
+                  type: 'url',
+                  url: url,
+                  value: url,
+                  source: text,
+                  title: title,
+                });
+              } else {
+                const [url, title] = text.split('|');
+                result.push({
+                  type: 'url',
+                  url: url,
+                  value: url,
+                  source: title ? `${url}|${title}` : url,
+                  title: title || url,
+                });
+              }
+            } else {
+              result.push({ type: 'text', value: text, source: text });
+            }
+          }
+        }
+      } else {
+        result.push(token);
+      }
+    } else {
+      result.push(token);
+    }
+  }
+  return result;
+}
+
+module.exports = (tokens) => {
+  let result = splitByPattern(
+    tokens,
+    /\[([\w\s\d]+)\]\((\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])\)/gi
+  );
+  return splitByPattern(
+    result,
+    /(\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
+  );
+};

--- a/packages/ast/parse/linen/listify/index.js
+++ b/packages/ast/parse/linen/listify/index.js
@@ -1,75 +1,3 @@
-function splitByPattern(tokens, pattern) {
-  const result = [];
-  for (let index = 0, length = tokens.length; index < length; index++) {
-    const token = tokens[index];
-    if (token.type === 'text') {
-      const { value } = token;
-      const matches = value.match(pattern);
-
-      if (matches) {
-        let indexes = [];
-        let needles = [];
-        let search = value.slice();
-        for (const match of matches) {
-          const start = search.indexOf(match);
-          const end = start + match.length;
-          indexes.push(start);
-          needles.push(start);
-          indexes.push(end);
-          search = search.replace(match, '_'.repeat(match.length));
-        }
-
-        if (indexes[0] !== 0) {
-          indexes.unshift(0);
-        }
-        if (indexes[indexes.length - 1] !== value.length) {
-          indexes.push(value.length);
-        }
-
-        for (let index = 0, length = indexes.length; index < length; index++) {
-          const current = indexes[index];
-          const next = indexes[index + 1];
-          if (typeof current === 'number' && typeof next === 'number') {
-            const text = value.substring(current, next);
-            if (needles.includes(current)) {
-              if (text.startsWith('[') && text.endsWith(')')) {
-                const title = text.substring(1, text.indexOf(']'));
-                const url = text.substring(
-                  text.indexOf('(') + 1,
-                  text.lastIndexOf(')')
-                );
-                result.push({
-                  type: 'url',
-                  url: url,
-                  value: url,
-                  source: text,
-                  title: title,
-                });
-              } else {
-                const [url, title] = text.split('|');
-                result.push({
-                  type: 'url',
-                  url: url,
-                  value: url,
-                  source: title ? `${url}|${title}` : url,
-                  title: title || url,
-                });
-              }
-            } else {
-              result.push({ type: 'text', value: text, source: text });
-            }
-          }
-        }
-      } else {
-        result.push(token);
-      }
-    } else {
-      result.push(token);
-    }
-  }
-  return result;
-}
-
 function tokenize(input) {
   const tokens = [];
   const length = input.length;
@@ -213,13 +141,5 @@ function splitByList(tokens) {
 }
 
 module.exports = (tokens) => {
-  let result = splitByPattern(
-    tokens,
-    /\[([\w\s\d]+)\]\((\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])\)/gi
-  );
-  result = splitByPattern(
-    result,
-    /(\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
-  );
-  return splitByList(result);
+  return splitByList(tokens);
 };


### PR DESCRIPTION
It might be necessary to move the list parsing as the first step if we want to allow more content inside of lists (e.g. inline code blocks or mentions).