### PR TITLE
Handle scroll for older browsers

### DIFF
--- a/packages/ui/src/ChannelView/ChatView/index.tsx
+++ b/packages/ui/src/ChannelView/ChatView/index.tsx
@@ -319,7 +319,7 @@ export default function Channel({
       isLeftScrollAtBottom ||
       isInViewport(leftBottomRef.current as HTMLElement)
     ) {
-      setTimeout(() => handleScroll, 0);
+      setTimeout(() => handleScroll(), 0);
     }
   }
 
@@ -399,7 +399,7 @@ export default function Channel({
   function scrollDown(offset = 0) {
     const scrollableRoot = scrollableRootRef.current;
     const lastScrollDistanceToBottom =
-      lastScrollDistanceToBottomRef.current ?? 0;
+      lastScrollDistanceToBottomRef.current || 0;
     if (scrollableRoot) {
       scrollableRoot.scrollTop =
         scrollableRoot.scrollHeight - lastScrollDistanceToBottom + offset;


### PR DESCRIPTION
Closes #1493 

It seems that `next.js` does not transform the `??` operator during the bundling process. We could use a [babel transform](https://babeljs.io/docs/babel-plugin-transform-nullish-coalescing-operator) to transform it, but it seems like an overkill given we just use it in like 10 files.