### PR TITLE
Bugfixes

### DIFF
--- a/apps/web/services/threads/index.ts
+++ b/apps/web/services/threads/index.ts
@@ -98,7 +98,6 @@ class ThreadsServices {
     channelId,
     resolutionId,
     externalThreadId,
-    message: messageBody,
   }: UpdateType) {
     const exist = await prisma.threads.findFirst({
       where: { id, channel: { accountId, id: channelId } },
@@ -123,16 +122,6 @@ class ThreadsServices {
         externalThreadId,
       },
     });
-
-    if (messageBody) {
-      const messageId = thread.messages[0].id;
-      await prisma.messages.update({
-        where: { id: messageId },
-        data: {
-          body: messageBody,
-        },
-      });
-    }
 
     if (exist.state !== thread.state) {
       if (thread.state === ThreadState.CLOSE) {

--- a/packages/ui/src/Actions/index.tsx
+++ b/packages/ui/src/Actions/index.tsx
@@ -114,7 +114,8 @@ export default function Actions({
   const isStarVisible = onStar && !!permissions?.starred;
   const isEmojiVisible = onEmoji && currentUser;
   const isResolutionVisible = onResolution && currentUser;
-  const isDragVisible = currentUser && draggable;
+  const isDragVisible =
+    thread.channel?.viewType === 'CHAT' && currentUser && draggable;
   const isDeleteVisible =
     onDelete &&
     currentUser &&

--- a/packages/ui/src/ChannelView/TopicView/Grid/index.tsx
+++ b/packages/ui/src/ChannelView/TopicView/Grid/index.tsx
@@ -83,7 +83,7 @@ export default function Grid({
   mode?: Mode;
   onClick: (threadId: string) => void;
   onDelete: (messageId: string) => void;
-  onEdit?: (threadId: string) => void;
+  onEdit?: (threadId: string, messageId: string) => void;
   onMute?: (threadId: string) => void;
   onUnmute?: (threadId: string) => void;
   onPin: (threadId: string) => void;

--- a/packages/ui/src/ChannelView/index.tsx
+++ b/packages/ui/src/ChannelView/index.tsx
@@ -811,17 +811,13 @@ export default function ChannelView({
         accountId: settings.communityId,
         id,
         title,
-        message,
-      })
-      .then(() => {
-        Toast.success('Updated successfully.');
       })
       .catch((_) => {
         Toast.error('Failed to edit the thread.');
       });
   };
 
-  const editMessage = ({
+  const editMessage = async ({
     id: messageId,
     body,
   }: {
@@ -855,9 +851,6 @@ export default function ChannelView({
         accountId: settings.communityId,
         id: messageId,
         body,
-      })
-      .then(() => {
-        Toast.success('Updated successfully.');
       })
       .catch((_) => {
         Toast.error('Failed to edit the message.');

--- a/packages/ui/src/GridContent/index.tsx
+++ b/packages/ui/src/GridContent/index.tsx
@@ -73,7 +73,7 @@ export default function GridContent({
   mode?: Mode;
   onClick: (threadId: string) => void;
   onDelete: (messageId: string) => void;
-  onEdit?: (threadId: string) => void;
+  onEdit?: (threadId: string, messageId: string) => void;
   onMute?: (threadId: string) => void;
   onUnmute?: (threadId: string) => void;
   onPin: (threadId: string) => void;

--- a/packages/ui/src/Thread/index.tsx
+++ b/packages/ui/src/Thread/index.tsx
@@ -72,7 +72,13 @@ interface Props {
     active: boolean;
   }): void;
   onResolution?: onResolve;
-  editMessage?({ id, body }: { id: string; body: string }): Promise<void>;
+  editMessage?({
+    id,
+    body,
+  }: {
+    id: string;
+    body: string;
+  }): Promise<SerializedMessage | void>;
   useUsersContext(): any;
   fetchMentions(term?: string | undefined): Promise<SerializedUser[]>;
   api: ApiClient;

--- a/packages/ui/src/ThreadView/Content/index.tsx
+++ b/packages/ui/src/ThreadView/Content/index.tsx
@@ -124,9 +124,6 @@ export default function Content({
         id,
         body,
       })
-      .then(() => {
-        Toast.success('Updated successfully.');
-      })
       .catch((_) => {
         Toast.error('Failed to update the message.');
       });


### PR DESCRIPTION
1. Show move feature only for the CHAT view type
2. Fix edit message in the topic view
3. Remove the option to update message via thread update endpoint, it's unsafe and can lead to race conditions (you could override someones message). Make a second API call, which is safer, has an explicit message id and checks permissions accordingly.