### PR TITLE
fix: Displaying the right logo in light and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 <p>
   <a href="https://linen.dev/">
-    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg" width="108">
+    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg#gh-light-mode-only" width="108">
+  </a>
+</p>
+
+<p>
+  <a href="https://linen.dev/">
+    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-white-logo.svg#gh-dark-mode-only" width="108">
   </a>
 </p>
 


### PR DESCRIPTION
Enabled displaying the right Linen Logo on the README file when it is opened in dark and light mode. Black logo appears in light mode. White logo appears in dark mode.