### PR TITLE
Fixed 2 Linen.dev Logos appearing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 [![Chat on - Linen](https://img.shields.io/badge/Chat_on-Linen-blue)](https://linen.dev/invite/linen)
 
-<p>
-  <a href="https://linen.dev/">
-    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg#gh-light-mode-only" width="108">
-  </a>
-</p>
+<a href="https://linen.dev/">
+  <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg#gh-light-mode-only" width="108">
+</a>
 
-<p>
-  <a href="https://linen.dev/">
-    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-white-logo.svg#gh-dark-mode-only" width="108">
-  </a>
-</p>
+<a href="https://linen.dev/">
+  <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-white-logo.svg#gh-dark-mode-only" width="108">
+</a>
 
 Linen is a Google-searchable community chat tool. Linen was built as an alternative to closed tools like Slack and Discord.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 <p>
   <a href="https://linen.dev/">
-    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg" width="108">
+    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg#gh-light-mode-only" width="108">
+  </a>
+</p>
+
+<p>
+  <a href="https://linen.dev/">
+    <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-white-logo.svg#gh-dark-mode-only" width="108">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Chat on - Linen](https://img.shields.io/badge/Chat_on-Linen-blue)](https://linen.dev/invite/linen)
 
-<a href="https://linen.dev/">
+<a href="https://linen.dev/#gh-light-mode-only">
   <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-black-logo.svg#gh-light-mode-only" width="108">
 </a>
 
-<a href="https://linen.dev/">
+<a href="https://linen.dev/#gh-dark-mode-only">
   <img alt="linen-dev" src="https://static.main.linendev.com/logos/linen-white-logo.svg#gh-dark-mode-only" width="108">
 </a>
 


### PR DESCRIPTION
After I saw that my pull request was accepted, I went to the repo's README to check it out. I was shocked to see two Linen logos appearing, both the white and black one. After a bit of research, I managed to find a fix for it.